### PR TITLE
D-Link DIR-615 D, add missing 'D'

### DIFF
--- a/lib/config_default.js
+++ b/lib/config_default.js
@@ -190,7 +190,7 @@ define([], function () {
       }
     },
     'deprecated': ['TP-Link TL-WR740N/ND v1',
-      'AP121', 'AP121U', 'D-Link DIR-615 D',
+      'AP121', 'AP121U', 'D-Link DIR-615', 'D-Link DIR-615 D',
       'TP-Link TL-MR13U v1', 'TP-Link TL-MR3020 v1', 'TP-Link TL-MR3040 v1', 'TP-Link TL-MR3040 v2',
       'TP-Link TL-MR3220 v1', 'TP-Link TL-MR3220 v2', 'TP-Link TL-MR3420 v1', 'TP-Link TL-MR3420 v2',
       'TP-Link TL-WA701N/ND v1', 'TP-Link TL-WA701N/ND v2', 'TP-Link TL-WA730RE v1', 'TP-Link TL-WA750RE v1',

--- a/lib/config_default.js
+++ b/lib/config_default.js
@@ -190,7 +190,7 @@ define([], function () {
       }
     },
     'deprecated': ['TP-Link TL-WR740N/ND v1',
-      'AP121', 'AP121U', 'D-Link DIR-615',
+      'AP121', 'AP121U', 'D-Link DIR-615 D',
       'TP-Link TL-MR13U v1', 'TP-Link TL-MR3020 v1', 'TP-Link TL-MR3040 v1', 'TP-Link TL-MR3040 v2',
       'TP-Link TL-MR3220 v1', 'TP-Link TL-MR3220 v2', 'TP-Link TL-MR3420 v1', 'TP-Link TL-MR3420 v2',
       'TP-Link TL-WA701N/ND v1', 'TP-Link TL-WA701N/ND v2', 'TP-Link TL-WA730RE v1', 'TP-Link TL-WA750RE v1',


### PR DESCRIPTION
Add Missing D,
so D-Link DIR-615 D is also shown as deprecated 