### PR TITLE
[BUGFIX] Allow defining geojson in config.json

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -82,11 +82,9 @@ define(['map/clientlayer', 'map/labellayer', 'map/button', 'leaflet', 'map/activ
 
       if (config.geo) {
         [].forEach.call(config.geo, function (geo) {
-          geo.json().then(function (result) {
-            if (result) {
-              L.geoJSON(result, geo.option).addTo(map);
-            }
-          });
+          if (geo) {
+            L.geoJSON(geo.json, geo.option).addTo(map);
+          }
         });
       }
 


### PR DESCRIPTION
<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above -->

## Description
This was not yet fixed for using the json instead of a js file.
It works now, for example by adding the following to the config.json:
```
"geo": [
  {
    "json": [
      {
        "type": "Feature",
        "geometry": {
          "type": "Polygon",
          "coordinates": [
            [
              [
                12.04925537109375,
                49.036517514836994
              ],
              [
                12.033462524414062,
                49.021660359632115
              ],
              [
                12.058181762695312,
                48.99553703238219
              ],
              [
                12.11311340332031,
                49.001843917978526
              ],
              [
                12.122726440429686,
                49.03381654386847
              ],
              [
                12.04925537109375,
                49.036517514836994
              ]
            ]
          ]
        }
      }
    ],
    "option": {
      "style": {
        "color": "#e23535",
        "weight": 5,
        "opacity": 0.4,
        "fillColor": "#6de922",
        "fillOpacity": 0.1
      }
    }
  }
],
```

## Motivation and Context

This allows to define polygons as overlay for borders

## How Has This Been Tested?

Define the given snippet in the config.json

## Screenshots/links (if appropriate):
![image](https://user-images.githubusercontent.com/25026204/184542501-37ac5f2b-3ac6-4182-b4cb-695a6fe5a8de.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


This is a followup PR for https://github.com/freifunk-ffm/meshviewer/pull/6
As the main branch was renamed, I could not reopen my old one.
If there is a working example to do it without this bugfix, I am happy to use it, but until then I have to use my fork containing this fix