### PR TITLE
[TASK] Add deprecation warning for

### DIFF
--- a/lib/config_default.js
+++ b/lib/config_default.js
@@ -191,6 +191,7 @@ define([], function () {
     },
     'deprecated': ['TP-Link TL-WR740N/ND v1',
       'AP121', 'AP121U', 'D-Link DIR-615', 'D-Link DIR-615 D',
+      'AVM FRITZ!Box 7320', 'AVM FRITZ!Box 7330', 'AVM FRITZ!Box 7330 SL',
       'TP-Link TL-MR13U v1', 'TP-Link TL-MR3020 v1', 'TP-Link TL-MR3040 v1', 'TP-Link TL-MR3040 v2',
       'TP-Link TL-MR3220 v1', 'TP-Link TL-MR3220 v2', 'TP-Link TL-MR3420 v1', 'TP-Link TL-MR3420 v2',
       'TP-Link TL-WA701N/ND v1', 'TP-Link TL-WA701N/ND v2', 'TP-Link TL-WA730RE v1', 'TP-Link TL-WA750RE v1',


### PR DESCRIPTION


<!--- Use a prefix like [TASK], [BUGFIX], [DOC] or [CGL] and provide a general summary of your changes in the Title above -->

## Description

Add deprecation warning for

* AVM FRITZ!Box 7320
* AVM FRITZ!Box 7330
* AVM FRITZ!Box 7330 SL
<!--- Describe your changes -->

## Motivation and Context

The devices have been dropped from gluon and are not likely to come back soon:
https://github.com/freifunk-gluon/gluon/commit/5231fb017800975bddaf655fa988055e007884be
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Not at all.
<!--- Please try to test the code in multiple browsers and also on a mobile device -->

## Screenshots/links (if appropriate):
This is the issue the devices have: https://github.com/freifunk-gluon/gluon/issues/1943

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
