### PR TITLE
Add deprecation warning for TL-WR1043N/ND v1

### DIFF
--- a/lib/config_default.js
+++ b/lib/config_default.js
@@ -208,6 +208,7 @@ define([], function () {
       'TP-Link TL-WR843N/ND v1',
       'TP-Link TL-WR940N v1', 'TP-Link TL-WR940N v2', 'TP-Link TL-WR940N v3', 'TP-Link TL-WR940N v4', 'TP-Link TL-WR940N v5', 'TP-Link TL-WR940N v6',
       'TP-Link TL-WR941N/ND v2', 'TP-Link TL-WR941N/ND v3', 'TP-Link TL-WR941N/ND v4', 'TP-Link TL-WR941N/ND v5', 'TP-Link TL-WR941N/ND v6',
+      'TP-Link TL-WR1043N/ND v1',
       'A5-V11', 'D-Link DIR-615 D1', 'D-Link DIR-615 D2', 'D-Link DIR-615 D3', 'D-Link DIR-615 D4', 'D-Link DIR-615 H1',
       'VoCore 8M', 'VoCore 16M']
   };


### PR DESCRIPTION
The device won't be coming back either.

8mb flash, 32mb memory, ath79