### PR TITLE
[TASK] adds filter for deprecationStatus and baseversion

### DIFF
--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -10,6 +10,8 @@ define(['d3-interpolate', 'snabbdom', 'utils/version', 'filters/genericnode', 'h
 
       var statusTable;
       var fwTable;
+      var baseTable;
+      var depTable;
       var hwTable;
       var geoTable;
       var autoTable;
@@ -96,6 +98,10 @@ define(['d3-interpolate', 'snabbdom', 'utils/version', 'filters/genericnode', 'h
           return d ? 'online' : 'offline';
         });
         var fwDict = count(nodes, ['firmware', 'release']);
+        var baseDict = count(nodes, ['firmware', 'base']);
+        var deprecationDict = count(nodes, ['model'], function (d) {
+          return config.deprecated && d && config.deprecated.includes(d) ? _.t('yes') : _.t('no');
+        });
         var hwDict = count(nodes, ['model']);
         var geoDict = count(nodes, ['location'], function (d) {
           return d && d.longitude && d.latitude ? _.t('yes') : _.t('no');
@@ -124,6 +130,10 @@ define(['d3-interpolate', 'snabbdom', 'utils/version', 'filters/genericnode', 'h
           return b[1] - a[1];
         }));
         fwTable = fillTable('node.firmware', fwTable, fwDict.sort(versionCompare));
+        baseTable = fillTable('node.baseversion', baseTable, baseDict.sort(versionCompare));
+        depTable = fillTable('node.deprecationStatus', depTable, deprecationDict.sort(function (a, b) {
+          return b[1] - a[1];
+        }));
         hwTable = fillTable('node.hardware', hwTable, hwDict.sort(function (a, b) {
           return b[1] - a[1];
         }));
@@ -147,6 +157,8 @@ define(['d3-interpolate', 'snabbdom', 'utils/version', 'filters/genericnode', 'h
       self.render = function render(el) {
         self.renderSingle(el, 'node.status', statusTable);
         self.renderSingle(el, 'node.firmware', fwTable);
+        self.renderSingle(el, 'node.baseversion', baseTable);
+        self.renderSingle(el, 'node.deprecationStatus', depTable);
         self.renderSingle(el, 'node.hardware', hwTable);
         self.renderSingle(el, 'node.visible', geoTable);
         self.renderSingle(el, 'node.update', autoTable);

--- a/locale/cz.json
+++ b/locale/cz.json
@@ -14,6 +14,8 @@
     "deactivated": "deaktivováno",
     "status": "Stav",
     "firmware": "Verze firmwaru",
+    "baseversion": "Base version",
+    "deprecationStatus": "Deprecation Status",
     "hardware": "Model hardwaru",
     "visible": "Visible on the map",
     "update": "Automatický update",

--- a/locale/de.json
+++ b/locale/de.json
@@ -14,6 +14,8 @@
     "deactivated": "deaktiviert",
     "status": "Status",
     "firmware": "Firmware-Version",
+    "baseversion": "Base Version",
+    "deprecationStatus": "Veralterungsstatus",
     "hardware": "Geräte-Modell",
     "visible": "Auf der Karte sichtbar",
     "update": "Auto-Update",

--- a/locale/en.json
+++ b/locale/en.json
@@ -14,6 +14,8 @@
     "deactivated": "deactivated",
     "status": "Status",
     "firmware": "Firmware version",
+    "baseversion": "Base version",
+    "deprecationStatus": "Deprecation Status",
     "hardware": "Hardware model",
     "visible": "Visible on the map",
     "update": "Auto update",

--- a/locale/fr.json
+++ b/locale/fr.json
@@ -14,6 +14,8 @@
     "deactivated": "désactivé",
     "status": "Statut",
     "firmware": "Version firmware",
+    "baseversion": "Base version",
+    "deprecationStatus": "Deprecation Status",
     "hardware": "Modèle matériel",
     "visible": "Visible sur la carte",
     "update": "Mise à jour automatique",

--- a/locale/ru.json
+++ b/locale/ru.json
@@ -14,6 +14,8 @@
     "deactivated": "деактивировано",
     "status": "Статус",
     "firmware": "Версия прошивки",
+    "baseversion": "Base version",
+    "deprecationStatus": "Deprecation Status",
     "hardware": "Тип оборудования",
     "visible": "Видно на карте",
     "update": "Автообновление",

--- a/locale/tr.json
+++ b/locale/tr.json
@@ -14,6 +14,8 @@
     "deactivated": "devredışı bırakıldı",
     "status": "Durum",
     "firmware": "Yazılım versiyonu",
+    "baseversion": "Base version",
+    "deprecationStatus": "Deprecation Status",
     "hardware": "Donanım modeli",
     "visible": "Harita üzerinde görünür",
     "update": "Otomatik güncelleme",


### PR DESCRIPTION
## Description
This adds a filter option for deprecationStatus and Base Version (mostly gluon base version, but also Debian/Ubuntu for supernodes)

## Motivation and Context
fixes #14 
fixes https://github.com/ffrgb/meshviewer/issues/334

## How Has This Been Tested?
<!--- Please try to test the code in multiple browsers and also on a mobile device -->

## Screenshots/links (if appropriate):

From FFAC domain:
![image](https://github.com/freifunk-ffm/meshviewer/assets/25026204/6bf9439b-72e8-4b69-a560-1c6bc3a84622)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
