### PR TITLE
[TASK] Hardware images for routers on the map

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -74,6 +74,7 @@
         "title": "Bild der Wochenstatistik"
       }
     ],
+    "hwImg": "https://map.aachen.freifunk.net/router-images/{MODEL_NORMALIZED}.svg",
     "node_custom": "/[^a-z0-9\\-\\.]/ig",
     "deprecation_text": "Hier kann ein eigener Text für die Deprecation Warning (inkl. HTML) stehen!",
     "deprecation_enabled": true

--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -167,7 +167,12 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'helper', 'utils/node'],
         V.patch(header, V.h('h2', d.hostname));
 
         var hwImg = showHwImg(config.hwImg, d);
-        hwImage = V.patch(hwImage, hwImg ? V.h('div', hwImg) : V.h('div'));
+        var hwImgContainerData = {
+          attrs: {
+            class: 'hw-img-container'
+          }
+        };
+        hwImage = V.patch(hwImage, hwImg ? V.h('div', hwImgContainerData, hwImg) : V.h('div'));
 
         var children = [];
 

--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -16,15 +16,16 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'helper', 'utils/node'],
 
     function showHwImg(o, d) {
       if (!d.model) {
-        return V.h('div');
+        return null;
       }
       var subst = {
         '{MODEL}': d.model,
         '{NODE_NAME}': d.hostname,
-        '{MODELHASH}': d.model.split('').reduce(function (a, b) {
+        '{MODEL_HASH}': d.model.split('').reduce(function (a, b) {
           a = ((a << 5) - a) + b.charCodeAt(0);
           return a & a;
-        }, 0)
+        }, 0),
+        '{MODEL_NORMALIZED}': d.model.toLowerCase().replace(/[^a-z0-9\-]/ig, '-')
       };
       return helper.showHwImg(V, o, subst);
     }

--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -25,7 +25,10 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'helper', 'utils/node'],
           a = ((a << 5) - a) + b.charCodeAt(0);
           return a & a;
         }, 0),
-        '{MODEL_NORMALIZED}': d.model.toLowerCase().replace(/[^a-z0-9\-]/ig, '-')
+        '{MODEL_NORMALIZED}': d.model.toLowerCase()
+          .replace(/[^a-z0-9\-]+/ig, '-')
+          .replace(/^-+/, '')
+          .replace(/-+$/, '')
       };
       return helper.showHwImg(V, o, subst);
     }

--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -14,6 +14,21 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'helper', 'utils/node'],
       return helper.showStat(V, o, subst);
     }
 
+    function showHwImg(o, d) {
+      if (!d.model) {
+        return V.h('div');
+      }
+      var subst = {
+        '{MODEL}': d.model,
+        '{NODE_NAME}': d.hostname,
+        '{MODELHASH}': d.model.split('').reduce(function (a, b) {
+          a = ((a << 5) - a) + b.charCodeAt(0);
+          return a & a;
+        }, 0)
+      };
+      return helper.showHwImg(V, o, subst);
+    }
+
     return function (el, d, linkScale, nodeDict) {
       function nodeLink(node) {
         return V.h('a', {
@@ -90,6 +105,7 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'helper', 'utils/node'],
 
       var self = this;
       var header = document.createElement('h2');
+      var hwImage = document.createElement('div');
       var table = document.createElement('table');
       var images = document.createElement('div');
       var neighbours = document.createElement('h3');
@@ -136,6 +152,7 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'helper', 'utils/node'],
       deprecation.innerHTML = '<div>' + (config.deprecation_text || _.t('deprecation')) + '</div>';
 
       el.appendChild(header);
+      el.appendChild(hwImage);
       el.appendChild(deprecation);
       el.appendChild(table);
       el.appendChild(neighbours);
@@ -144,6 +161,9 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'helper', 'utils/node'],
 
       self.render = function render() {
         V.patch(header, V.h('h2', d.hostname));
+
+        var hwImg = showHwImg(config.hwImg, d);
+        hwImage = V.patch(hwImage, hwImg ? V.h('div', hwImg) : V.h('div'));
 
         var children = [];
 

--- a/lib/utils/helper.js
+++ b/lib/utils/helper.js
@@ -136,7 +136,13 @@ define({
       return null;
     }
 
-    return V.h('img', { attrs: { src: require('helper').listReplace(o, subst), width: '25%' } });
+    return V.h('img', {
+      attrs: { src: require('helper').listReplace(o, subst), width: '35%' },
+      on: {
+        // hide non-existant images
+        error: function (e) { e.target.style.display = 'none'; }
+      }
+    });
   },
 
   getTileBBox: function getTileBBox(s, map, tileSize, margin) {

--- a/lib/utils/helper.js
+++ b/lib/utils/helper.js
@@ -131,6 +131,13 @@ define({
     }
     return V.h('div', content);
   },
+  showHwImg: function showHwImg(V, o, subst) {
+    if (!o) {
+      return null;
+    }
+
+    return V.h('img', { attrs: { src: require('helper').listReplace(o, subst), width: '25%' } });
+  },
 
   getTileBBox: function getTileBBox(s, map, tileSize, margin) {
     var tl = map.unproject([s.x - margin, s.y - margin]);

--- a/lib/utils/helper.js
+++ b/lib/utils/helper.js
@@ -137,7 +137,7 @@ define({
     }
 
     return V.h('img', {
-      attrs: { src: require('helper').listReplace(o, subst), width: '35%' },
+      attrs: { src: require('helper').listReplace(o, subst), class: 'hwImg'},
       on: {
         // hide non-existant images
         error: function (e) { e.target.style.display = 'none'; }

--- a/lib/utils/helper.js
+++ b/lib/utils/helper.js
@@ -137,7 +137,7 @@ define({
     }
 
     return V.h('img', {
-      attrs: { src: require('helper').listReplace(o, subst), class: 'hwImg'},
+      attrs: { src: require('helper').listReplace(o, subst), class: 'hw-img'},
       on: {
         // hide non-existant images
         error: function (e) { e.target.style.display = 'none'; }

--- a/scss/modules/_base.scss
+++ b/scss/modules/_base.scss
@@ -114,3 +114,9 @@ strong {
     }
   }
 }
+
+.hwImg {
+  width: 35%;
+  margin: auto;
+  display: block;
+}

--- a/scss/modules/_base.scss
+++ b/scss/modules/_base.scss
@@ -115,8 +115,14 @@ strong {
   }
 }
 
-.hwImg {
-  width: 35%;
-  margin: auto;
-  display: block;
+.hw-img-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: .83em;
+  width: 100%;
+}
+
+.hw-img {
+  height: 150px;
+  padding: 0 !important;
 }


### PR DESCRIPTION
## Description
This adds the option to set an url where hardware images can be fetched from.

These are then shown per router, as can be seen here:

![image](https://github.com/freifunk-ffm/meshviewer/assets/25026204/2766d39c-a8e7-4d8d-be8c-a31edcf04366)

## Motivation and Context
This is a very nice feature which is available in hopglass but wasn't available in meshviewer until now.
It helps to recognize how the router looks like.

To create an image source, one can either use existing ones like:
`https://cdn.rawgit.com/Moorviper/meshviewer_hwpics/master/nodes/{MODEL_HASH}.svg`
`https://map.eulenfunk.de/nodes/{MODEL_HASH}.svg`
or a [bash script as described here](https://forum.freifunk.net/t/mithilfe-aufruf-aktuelle-firmware-selector-bilder/23821/4)
`https://map.aachen.freifunk.net/router-images/{MODEL_NORMALIZED}.svg`

## How Has This Been Tested?
This patchset is currently active in Aachen, see:
https://map.aachen.freifunk.net

## Screenshots/links (if appropriate):

## Checklist:
- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
