### PR TITLE
[BUGFIX] Revert "npm: bump navigo from 7.1.3 to 8.11.1" as that change breaks the map (duh)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "fsevents": "^2.3.3",
         "leaflet": "^1.7.1",
         "moment": "^2.29.4",
-        "navigo": "^8.11.1",
+        "navigo": "^7.1.2",
         "node-polyglot": "2.2.2",
         "promise-polyfill": "^8.2.0",
         "rbush": "^3.0.1",
@@ -9035,9 +9035,9 @@
       "dev": true
     },
     "node_modules/navigo": {
-      "version": "8.11.1",
-      "resolved": "https://registry.npmjs.org/navigo/-/navigo-8.11.1.tgz",
-      "integrity": "sha512-e3sc1UzakF+bWquC8/dbPCgo7LgPEW1ekgwb4pmEcl8tOc/I7lML8r7HBql+b0VRk7tJWTZqtkeObwJAVR1pxg=="
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/navigo/-/navigo-7.1.3.tgz",
+      "integrity": "sha512-dFsj+a0ml09P4rtX8xzsPl/SXb15YOTes7vjDSTsifRAMJ400+M4Hb5oiI9L5fhmaILBrzp0Y0o0+DZ+f3NLfw=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "d3-zoom": "^3.0.0",
     "leaflet": "^1.7.1",
     "moment": "^2.29.4",
-    "navigo": "^8.11.1",
+    "navigo": "^7.1.2",
     "node-polyglot": "2.2.2",
     "promise-polyfill": "^8.2.0",
     "rbush": "^3.0.1",


### PR DESCRIPTION
## Description
@skorpy2009 broke it during updates, this should fix it temporarily

## Motivation and Context
Fixing stuff

## How Has This Been Tested?
Local dev env

## Screenshots/links (if appropriate):
-

## Checklist:
- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
