### PR TITLE
correctly apply hw-img class to img tag

### DIFF
--- a/lib/utils/helper.ts
+++ b/lib/utils/helper.ts
@@ -168,7 +168,8 @@ export const showDevicePicture = function showDevicePicture(pictures: string, su
   }
 
   return h("img", {
-    props: { src: listReplace(pictures, subst), class: "hw-img" },
+    props: { src: listReplace(pictures, subst) },
+    class: { "hw-img": true },
     on: {
       // hide non-existent images
       error: function (e: any) {


### PR DESCRIPTION

## Description
the hw-img class was not applied to the img

## Motivation and Context
svg images did not have a max-size of 150px because of this.

See here for more information: https://forum.freifunk.net/t/meshviewer-router-icon-svg-groesse-einstellen/24429

## How Has This Been Tested?
by using the desktop view and making sure that the img now has the correct class applied

## Screenshots/links:

Before:

![image](https://github.com/user-attachments/assets/9f83e575-765e-4220-971b-fbf6c32425a5)

After:

![image](https://github.com/user-attachments/assets/68228ab4-75d1-430e-af75-a7f7a9bd9769)

The error has been introduced after: 9eab1c51bfb6f440b5b90ee8b541fdf1ad2425f0 (last working commit)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
