### PR TITLE
helper: NodeInfo can also be a link without image

### DIFF
--- a/lib/utils/helper.ts
+++ b/lib/utils/helper.ts
@@ -1,5 +1,5 @@
 import { Moment } from "moment";
-import { h, VNode } from "snabbdom";
+import { h, Props, VNode, VNodeChildren, VNodeData } from "snabbdom";
 import { Map } from "leaflet";
 import { _ } from "./language.js";
 import { Node } from "./node.js";
@@ -134,14 +134,19 @@ export function attributeEntry(children: VNode[], label: string, value: string |
 }
 
 export function showStat(linkInfo: LinkInfo, subst: ReplaceMapping): HTMLDivElement {
-  let content = h("img", {
-    props: {
-      src: listReplace(linkInfo.image, subst),
-      width: linkInfo.width,
-      height: linkInfo.height,
-      alt: _.t("loading", { name: linkInfo.name }),
-    },
-  });
+  let content: VNode;
+  if (linkInfo.image) {
+    content = h("img", {
+      props: {
+        src: listReplace(linkInfo.image, subst),
+        width: linkInfo.width,
+        height: linkInfo.height,
+        alt: _.t("loading", { name: linkInfo.name }),
+      },
+    });
+  } else {
+    content = h("p", listReplace(linkInfo.title, subst));
+  }
 
   if (linkInfo.href) {
     return h(


### PR DESCRIPTION

## Description

Using the following snippet in `nodeInfos` one can add a wiki link to the nodes:

```json
    {
      "name": "Node wiki",
      "title": "https://wiki.example.com/{NODE_ID}",
      "href": "https://wiki.example.com/{NODE_ID}" 
    },
```

## Motivation and Context

closes #207

## How Has This Been Tested?

The snippet above has been used for testing

## Screenshots/links:

<img width="773" height="591" alt="image" src="https://github.com/user-attachments/assets/9f9cd2da-af0a-4391-a07f-0b546729a11b" />



## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
