### PR TITLE
removed the twitter_handle

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@
     <meta property="business:contact_data:country_name" content="Germany" />
 
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:site" content="@freifunk" />
 
     <meta name="og:title" content="Meshviewer" />
     <meta


### PR DESCRIPTION
hi maintainer please review this pr for the issue #107 
This PR removes the hard-coded Twitter/X meta tag from index.html
<meta name="twitter:site" content="@freifunk" />
thanks maintainer for maintaining the project !! 

I’m interested in contributing and wanted to know if your organization has a Slack/Discord channel for community discussions or GSoC-related communication. Could you please share the details if available?