### PR TITLE
Fix: About dialog legend uses runtime config colors

### DIFF
--- a/lib/about.ts
+++ b/lib/about.ts
@@ -84,7 +84,7 @@ export const About = function (picturesSource: string, picturesLicense: string):
 
     // According to maintainer’s valid config JSON:
     applyColor(".legend-online .symbol", "online");
-    applyColor(".legend-online-uplink .symbol", "online.uplink");
+    applyColor(".legend-uplink .symbol", "online.uplink");
     applyColor(".legend-offline .symbol", "offline");
     applyColor(".legend-lost .symbol", "lost");
     applyColor(".legend-alert .symbol", "alert");


### PR DESCRIPTION
The About dialog legend now reads colors from the runtime [config] and applies them to the legend symbols so legend colors match the colors used on the map.

After rendering the About dialog, read [window.config] and apply inline color styles to the legend symbols so they reflect [config.icon.*] and [config.client.*] values at runtime. The code is defensive with fallbacks and wrapped in try/catch to avoid runtime errors if [config] is missing.

*Files changed*:
[about.ts] — apply runtime colors inside [render(d: HTMLElement(main fix).
[_icon.scss] — add correct [@mixin icon(...)](fix for build).
[_icon.scss] — updated to [@use "../../../assets/icons/icon]