### PR TITLE
fix: also apply customized colors to the legend

### DIFF
--- a/lib/about.ts
+++ b/lib/about.ts
@@ -2,6 +2,25 @@ import { _ } from "./utils/language.js";
 import { CanRender } from "./container.js";
 
 export const About = function (picturesSource: string, picturesLicense: string): CanRender {
+  function applyCustomLegendStyle(d: HTMLElement) {
+    const iconConfig = window.config.icon;
+
+    // apply custom styling from config.json to reflect changes in config.json
+    const applyColor = (selector: string, key: string) => {
+      // this applies the color config like Leaflet circleMarker config does
+      const el = d.querySelector(selector) as HTMLElement;
+      const cfgIcon = iconConfig[key];
+
+      el.style.backgroundColor = cfgIcon.fillColor;
+      el.style.borderColor = cfgIcon.color;
+    };
+    applyColor(".legend-new .symbol", "new");
+    applyColor(".legend-online .symbol", "online");
+    applyColor(".legend-offline .symbol", "offline");
+    // first apply online color, then add uplink specialized
+    applyColor(".legend-uplink .symbol", "online");
+    applyColor(".legend-uplink .symbol", "online.uplink");
+  }
   function render(d: HTMLElement) {
     d.innerHTML =
       _.t("sidebar.aboutInfo") +
@@ -63,6 +82,9 @@ export const About = function (picturesSource: string, picturesLicense: string):
       "<p>The source code is available at " +
       '<a href="https://github.com/freifunk/meshviewer">' +
       "https://github.com/freifunk/meshviewer</a>.</p>";
+
+    // Apply runtime colors from config if available so the legend matches the map
+    applyCustomLegendStyle(d);
   }
 
   return {


### PR DESCRIPTION
## Description

When a custom color for new, online, offline or lost is set on the map, the legend in the about config is now adjusted as well.

## Motivation and Context

fixes #7 

## How Has This Been Tested?

Tested using the config from FFAC and FFMUC

## Screenshots/links:

<img width="1355" height="659" alt="image" src="https://github.com/user-attachments/assets/0443acf0-a5ed-48bf-9c9e-d185650702a6" />

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
