### PR TITLE
feat: colorize links of type other

### DIFF
--- a/lib/config_default.ts
+++ b/lib/config_default.ts
@@ -134,6 +134,7 @@ export interface Config {
     tqFrom: string;
     tqTo: string;
     zoomModifier: number;
+    otherLinkColor: string;
   };
   locate: {
     outerCircle: {
@@ -332,6 +333,7 @@ export const config: Config = {
     tqFrom: "#770038",
     tqTo: "#dc0067",
     zoomModifier: 1,
+    otherLinkColor: "#5194ecff",
   },
   locate: {
     outerCircle: {

--- a/lib/forcegraph/draw.ts
+++ b/lib/forcegraph/draw.ts
@@ -103,6 +103,7 @@ self.drawNode = function drawNode(node: MapNode) {
 };
 
 self.drawLink = function drawLink(link: MapLink) {
+  let config = window.config;
   let zero = transform.invert([0, 0]);
   let area = transform.invert([width, height]);
   if (
@@ -120,18 +121,24 @@ self.drawLink = function drawLink(link: MapLink) {
   to = drawHighlightLink(link, to);
 
   let grd = ctx.createLinearGradient(link.source.x, link.source.y, link.target.x, link.target.y);
-  grd.addColorStop(0.45, link.color);
-  grd.addColorStop(0.55, link.color_to);
 
   ctx.lineTo(to[0], to[1]);
-  ctx.strokeStyle = grd;
   if (link.o.type.indexOf("vpn") === 0) {
     ctx.globalAlpha = 0.2;
     ctx.lineWidth = 1.5;
+  } else if (link.o.type.indexOf("other") === 0) {
+    ctx.globalAlpha = 1;
+    ctx.lineWidth = 3.5;
+    link.color = config.forceGraph.otherLinkColor;
+    link.color_to = config.forceGraph.otherLinkColor;
   } else {
     ctx.globalAlpha = 0.8;
     ctx.lineWidth = 2.5;
   }
+
+  grd.addColorStop(0.45, link.color);
+  grd.addColorStop(0.55, link.color_to);
+  ctx.strokeStyle = grd;
   ctx.stroke();
   ctx.globalAlpha = 1;
 };

--- a/lib/map/labellayer.js
+++ b/lib/map/labellayer.js
@@ -110,8 +110,15 @@ function addLinksToMap(dict, linkScale, graph) {
   });
 
   return graph.map(function (link) {
+    let linkColor;
+    if (link.type.indexOf("other") == 0) {
+      linkColor = "#50B0F0";
+    } else {
+      linkColor = linkScale((link.source_tq + link.target_tq) / 2);
+    }
+
     let opts = {
-      color: linkScale((link.source_tq + link.target_tq) / 2),
+      color: linkColor,
       weight: 4,
       opacity: 0.5,
       dashArray: "none",


### PR DESCRIPTION
## Description

This adds the functionality to have wired links colored in blue.

fixes #260

The used color can be configured with `otherLinkColor`

## Motivation and Context

This is a required feature for different communities to make the move from hopglass to meshviewer.

Currently, this is not configurable - maybe this is needed here.

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

<img width="1162" height="785" alt="image" src="https://github.com/user-attachments/assets/f3920231-abc2-4fe7-b0ee-beae8894acd8" />


<img width="1347" height="716" alt="image" src="https://github.com/user-attachments/assets/1e24f0c4-3d37-474c-aa49-bd713a9b78bf" />


## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
