### PR TITLE
only draw  link colored for others if tq is higher equals 0.99

### DIFF
--- a/lib/forcegraph/draw.ts
+++ b/lib/forcegraph/draw.ts
@@ -129,8 +129,10 @@ self.drawLink = function drawLink(link: MapLink) {
   } else if (link.o.type.indexOf("other") === 0) {
     ctx.globalAlpha = 1;
     ctx.lineWidth = 3.5;
-    link.color = config.forceGraph.otherLinkColor;
-    link.color_to = config.forceGraph.otherLinkColor;
+    if (link.o.source_tq >= 0.99 && link.o.target_tq >= 0.99) {
+      link.color = config.forceGraph.otherLinkColor;
+      link.color_to = config.forceGraph.otherLinkColor;
+    }
   } else {
     ctx.globalAlpha = 0.8;
     ctx.lineWidth = 2.5;


### PR DESCRIPTION
This is to accomodate for mesh links which have a point-to-point radio component in between.

This was mentioned by @skorpy2009  as an improvement to the colorization feature.