### PR TITLE
cleanup code and fix default of deep links in generateLink function

### DIFF
--- a/lib/gui.ts
+++ b/lib/gui.ts
@@ -88,7 +88,7 @@ export const Gui = function (language: ReturnType<typeof Language>) {
     } else {
       data = { view: "map" };
     }
-    router.fullUrl(data, false, true);
+    router.deepUrl(data);
   };
 
   buttons.appendChild(buttonToggle);

--- a/lib/utils/language.ts
+++ b/lib/utils/language.ts
@@ -27,7 +27,7 @@ export const Language = function () {
   }
 
   function setSelectLocale(event: any) {
-    router.fullUrl({ lang: event.target.value }, false, true);
+    router.deepUrl({ lang: event.target.value });
   }
 
   function getLocale(input?: LanguageCode): LanguageCode {

--- a/lib/utils/router.ts
+++ b/lib/utils/router.ts
@@ -163,12 +163,12 @@ export class Router extends Navigo {
       });
   }
 
-  generateLink(data?: {}, full?: boolean, deep?: boolean) {
+  generateLink(data?: {}, full?: boolean) {
     let result = "";
 
     if (full) {
       data = Object.assign({}, this.state, data);
-    } else if (deep) {
+    } else {
       result = "#";
       data = Object.assign({}, this.currentState, data);
     }
@@ -183,11 +183,18 @@ export class Router extends Navigo {
     return result;
   }
 
-  fullUrl(data?: {}, e?: Event | false, deep?: boolean) {
+  fullUrl(data?: {}, e?: Event | false) {
     if (e) {
       e.preventDefault();
     }
-    this.navigate(this.generateLink(data, !deep, deep));
+    this.navigate(this.generateLink(data, true));
+  }
+
+  deepUrl(data?: {}, e?: Event | false) {
+    if (e) {
+      e.preventDefault();
+    }
+    this.navigate(this.generateLink(data));
   }
 
   getLang() {


### PR DESCRIPTION
Closes #262 

This was introduced with the updated navigo router in #132

introduces a new deepUrl function instead of calling the fullUrl function in a way which produces a deepUrl.
Using `generateLink` to create links which are neither full nor deep is not used anywhere.