### PR TITLE
fix: the full link to the graph

### DIFF
--- a/lib/gui.ts
+++ b/lib/gui.ts
@@ -88,7 +88,7 @@ export const Gui = function (language: ReturnType<typeof Language>) {
     } else {
       data = { view: "map" };
     }
-    router.deepUrl(data);
+    router.fullUrl(data);
   };
 
   buttons.appendChild(buttonToggle);


### PR DESCRIPTION
The link did not work when opening as a new tab or sharing the URL

like https://mapserver/#/en/graph