### PR TITLE
[BUGFIX] Fix long contact URLs breaking sidebar layout in Chrome

### DIFF
--- a/scss/modules/_table.scss
+++ b/scss/modules/_table.scss
@@ -20,6 +20,8 @@ table {
     td {
       text-align: left;
       width: 100%;
+      overflow-wrap: break-word;
+      word-break: break-word;
     }
   }
 }


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

<!-- Describe your changes -->

Added `overflow-wrap: break-word` and `word-break: break-word` CSS properties to table cells in the `.attributes` table to properly wrap long text content like URLs.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes #285

Long contact information (URLs) in the node details sidebar break the layout in Chrome. The URL escapes the sidebar container because Chrome handles word-breaking differently than other browsers. This fix ensures long unbroken strings like URLs wrap properly within the sidebar.

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

- Tested in Chrome (where the issue was originally reported) - URL now wraps correctly
- Tested with the node at https://hopglass.berlin.freifunk.net/#/de/map/f427f95df640 which has a long contact URL


I'm sure about the long url wrap fix but not about the Load Average bar. I tried to use the meshviewer.json's data, downloaded and loaded it locally, it worked locally.

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

**Before:** Long URLs escape the sidebar container in Chrome
**After:** URLs wrap properly within the sidebar

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
