### PR TITLE
[BUGFIX] refresh hostname filter without observer

### DIFF
--- a/lib/datadistributor.ts
+++ b/lib/datadistributor.ts
@@ -67,11 +67,13 @@ export const DataDistributor = function () {
     refresh();
   }
 
-  function refresh() {
+  function refresh(withoutObservers?: boolean) {
     if (data === undefined) {
       return;
     }
-    notifyObservers();
+    if (!withoutObservers) {
+      notifyObservers();
+    }
 
     let filter: FilterMethod = filters.reduce(
       function (a: FilterMethod, filter) {

--- a/lib/filters/hostname.ts
+++ b/lib/filters/hostname.ts
@@ -4,7 +4,7 @@ import { CanRender } from "../container.js";
 import { Filter } from "../datadistributor.js";
 
 export const HostnameFilter = function (): CanRender & Filter {
-  let refreshFunctions: (() => any)[] = [];
+  let refreshFunctions: ((bool?) => any)[] = [];
   let timer: ReturnType<typeof setTimeout>;
   let input = document.createElement("input");
 
@@ -12,7 +12,9 @@ export const HostnameFilter = function (): CanRender & Filter {
     clearTimeout(timer);
     timer = setTimeout(function () {
       refreshFunctions.forEach(function (f) {
-        f();
+        // observer gui function recreates the filter this removes the input focus
+        // the hostname filter should therefore not notifyObservers on refresh
+        f(true);
       });
     }, 250);
   }


### PR DESCRIPTION
in v13.0.0 a bug was introduced which loses focus when searching in the node bar.

This is due to the constant removal and readdition of the filter search bar.
The issue is fixed by not calling the notifyObservers for the hostname filter (which is needed to update the URL params).

fixes d45c19b8e9d9

<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

<!-- Describe your changes -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
