### PR TITLE
[BUGFIX] break long contact url in detail table view

### DIFF
--- a/scss/modules/_table.scss
+++ b/scss/modules/_table.scss
@@ -20,6 +20,7 @@ table {
     td {
       text-align: left;
       width: 100%;
+      overflow-wrap: anywhere;
     }
   }
 }


### PR DESCRIPTION

## Description

fixes #285

thanks @noki for suggesting a fix already.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Chromium:

<img width="779" height="395" alt="image" src="https://github.com/user-attachments/assets/dc5163b1-4c66-4aca-a7cb-08b3d0d2f750" />

Firefox (looks similar as without the fix):

<img width="779" height="395" alt="image" src="https://github.com/user-attachments/assets/56931387-a322-4103-8fcc-2435f1218aee" />


<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
