### PR TITLE
[BUGFIX] the colorization of links should only happen if the tq is high

### DIFF
--- a/lib/map/labellayer.js
+++ b/lib/map/labellayer.js
@@ -112,7 +112,7 @@ function addLinksToMap(dict, linkScale, graph) {
 
   return graph.map(function (link) {
     let linkColor;
-    if (link.type.indexOf("other") == 0) {
+    if (link.type.indexOf("other") == 0 && link.source_tq >= 0.99 && link.target_tq >= 0.99) {
       linkColor = config.map.otherLinkColor;
     } else {
       linkColor = linkScale((link.source_tq + link.target_tq) / 2);


### PR DESCRIPTION
## Description

This feature was added in #264.
However, the calculation to only colorize sufficiently stable connections in blue was missing on the map view and only made it to the forcegraph. @skorpy2009 

<!-- Describe your changes -->

## Motivation and Context

Links of type other with bad TQ should also show the quality.
Such links might not be wired at all (e.g. P2P wireless inbetween) and therefore should show as normal links.

Example here: https://map.aachen.freifunk.net/#/en/map/001b215925ad-a0f3c1780868

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
