### PR TITLE
add maxZoom for vectore

### DIFF
--- a/lib/map.ts
+++ b/lib/map.ts
@@ -86,11 +86,11 @@ export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typ
       name: layer.name,
       layer:
         layer.type == "vector"
-          ? L.maplibreGL({ 
-            style: layer.url, 
-            attributionControl: { customAttribution: layer.config.attribution },
-            maxZoom: layer.config.maxZoom,
-          })
+          ? L.maplibreGL({
+              style: layer.url,
+              attributionControl: { customAttribution: layer.config.attribution },
+              maxZoom: layer.config.maxZoom,
+            })
           : L.tileLayer(
               layer.url.replace(
                 "{format}",


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description
`maxZoom` was missing when using vectore
still missing is `order` and `mode` (for nightmode)
<!-- Describe your changes -->

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested via Codespaces `npm install` and `npm run dev` and custom vectore tiles config:
https://github.com/freifunkMUC/meshviewer/tree/test-vectore


<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

layers array bevor:
```json
[
    {
        "name": "versatiles light",
        "layer": {
            "options": {
                "style": "light.json",
                "attributionControl": {
                    "customAttribution": "<a href='https://github.com/freifunk/meshviewer/issues' target='_blank'>Report Bug</a> | Map data &copy; <a href\"http://openstreetmap.org\">OpenStreetMap</a> contributor"
                }
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "versatiles dark",
        "layer": {
            "options": {
                "style": "dark.json",
                "attributionControl": {
                    "customAttribution": "<a href='https://github.com/freifunk/meshviewer/issues' target='_blank'>Report Bug</a> | Map data &copy; <a href\"http://openstreetmap.org\">OpenStreetMap</a> contributor"
                }
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "FFMUC OSM Proxy",
        "layer": {
            "options": {
                "maxZoom": 19,
                "attribution": "&copy; Openstreetmap | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>",
                "order": 2,
                "subdomains": [
                    "a",
                    "b",
                    "c"
                ]
            },
            "_url": "https://tiles.ext.ffmuc.net/osm/{z}/{x}/{y}.png",
            "_events": {
                "tileunload": [
                    {}
                ]
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "FFMUC OSM Proxy (Night)",
        "layer": {
            "options": {
                "maxZoom": 19,
                "mode": "night",
                "attribution": "&copy; Openstreetmap | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>",
                "order": 3,
                "subdomains": [
                    "a",
                    "b",
                    "c"
                ]
            },
            "_url": "https://tiles.ext.ffmuc.net/osm/{z}/{x}/{y}.png",
            "_events": {
                "tileunload": [
                    {}
                ]
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "FFMUC OSM.HOT Proxy",
        "layer": {
            "options": {
                "maxZoom": 20,
                "attribution": "&copy; Openstreetmap France | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>",
                "order": 4,
                "subdomains": [
                    "a",
                    "b",
                    "c"
                ]
            },
            "_url": "https://tiles.ext.ffmuc.net/hot/{z}/{x}/{y}.png",
            "_events": {
                "tileunload": [
                    {}
                ]
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "Esri.WorldImagery",
        "layer": {
            "options": {
                "maxZoom": 20,
                "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
                "order": 5,
                "subdomains": [
                    "a",
                    "b",
                    "c"
                ]
            },
            "_url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
            "_events": {
                "tileunload": [
                    {}
                ]
            },
            "_initHooksCalled": true
        }
    }
]

```
layers array now:
```json
[
    {
        "name": "versatiles light",
        "layer": {
            "options": {
                "style": "light.json",
                "attributionControl": {
                    "customAttribution": "<a href='https://github.com/freifunk/meshviewer/issues' target='_blank'>Report Bug</a> | Map data &copy; <a href\"http://openstreetmap.org\">OpenStreetMap</a> contributor"
                },
                "maxZoom": 19
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "versatiles dark",
        "layer": {
            "options": {
                "style": "dark.json",
                "attributionControl": {
                    "customAttribution": "<a href='https://github.com/freifunk/meshviewer/issues' target='_blank'>Report Bug</a> | Map data &copy; <a href\"http://openstreetmap.org\">OpenStreetMap</a> contributor"
                },
                "maxZoom": 19
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "FFMUC OSM Proxy",
        "layer": {
            "options": {
                "maxZoom": 19,
                "attribution": "&copy; Openstreetmap | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>",
                "order": 2,
                "subdomains": [
                    "a",
                    "b",
                    "c"
                ]
            },
            "_url": "https://tiles.ext.ffmuc.net/osm/{z}/{x}/{y}.png",
            "_events": {
                "tileunload": [
                    {}
                ]
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "FFMUC OSM Proxy (Night)",
        "layer": {
            "options": {
                "maxZoom": 19,
                "mode": "night",
                "attribution": "&copy; Openstreetmap | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>",
                "order": 3,
                "subdomains": [
                    "a",
                    "b",
                    "c"
                ]
            },
            "_url": "https://tiles.ext.ffmuc.net/osm/{z}/{x}/{y}.png",
            "_events": {
                "tileunload": [
                    {}
                ]
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "FFMUC OSM.HOT Proxy",
        "layer": {
            "options": {
                "maxZoom": 20,
                "attribution": "&copy; Openstreetmap France | &copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>",
                "order": 4,
                "subdomains": [
                    "a",
                    "b",
                    "c"
                ]
            },
            "_url": "https://tiles.ext.ffmuc.net/hot/{z}/{x}/{y}.png",
            "_events": {
                "tileunload": [
                    {}
                ]
            },
            "_initHooksCalled": true
        }
    },
    {
        "name": "Esri.WorldImagery",
        "layer": {
            "options": {
                "maxZoom": 20,
                "attribution": "Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community",
                "order": 5,
                "subdomains": [
                    "a",
                    "b",
                    "c"
                ]
            },
            "_url": "//server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
            "_events": {
                "tileunload": [
                    {}
                ]
            },
            "_initHooksCalled": true
        }
    }
]

```

setting breakpoints works good to get all the infos
without zoom:
<img width="1403" height="995" alt="image" src="https://github.com/user-attachments/assets/2a73e2d5-1cc5-4ca9-a8b8-1fb8b1d9cf90" />

with zoom:
<img width="1370" height="789" alt="image" src="https://github.com/user-attachments/assets/dc75bb05-6d2e-4589-a9c8-c89ed58be8bc" />
