### PR TITLE
ci: add per-PR preview deployments to gh-pages

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,29 @@
+name: PR Preview Build
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+concurrency:
+  group: preview-build-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      VITE_PREVIEW: "1"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/build-preview-fixtures.mjs
+      - run: echo "${{ github.event.pull_request.number }}" > build/.pr-number
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-preview-build
+          path: build/
+          retention-days: 7
+          include-hidden-files: true

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,29 @@
+name: PR Preview Cleanup
+on:
+  pull_request:
+    types: [closed]
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+      - name: Remove preview directory
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          rm -rf "pr-preview/pr-${{ github.event.pull_request.number }}"
+          git add -A
+          git diff --cached --quiet || git commit -m "preview: cleanup PR #${{ github.event.pull_request.number }}"
+          git push
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: "Preview for this PR has been removed."

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,52 @@
+name: PR Preview Deploy
+on:
+  workflow_run:
+    workflows: ["PR Preview Build"]
+    types: [completed]
+concurrency:
+  group: gh-pages-deploy
+  cancel-in-progress: false
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+jobs:
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment:
+      name: pr-preview
+      url: ${{ steps.url.outputs.url }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pr-preview-build
+          path: build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - id: pr
+        run: echo "number=$(cat build/.pr-number)" >> "$GITHUB_OUTPUT"
+      - run: rm build/.pr-number
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: gh-pages
+      - name: Remove stale assets from prior pushes to this PR
+        run: rm -rf "gh-pages/pr-preview/pr-${{ steps.pr.outputs.number }}"
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          destination_dir: pr-preview/pr-${{ steps.pr.outputs.number }}
+          keep_files: true
+          commit_message: "preview: deploy PR #${{ steps.pr.outputs.number }}"
+      - id: url
+        run: echo "url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ steps.pr.outputs.number }}/" >> "$GITHUB_OUTPUT"
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          header: pr-preview
+          message: |
+            **Preview deployed:** ${{ steps.url.outputs.url }}
+
+            Updated for commit ${{ github.event.workflow_run.head_sha }}.

--- a/scripts/build-preview-fixtures.mjs
+++ b/scripts/build-preview-fixtures.mjs
@@ -1,0 +1,22 @@
+import { readFileSync, writeFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { resolveRelativeFixtureTimes } from "./fixture-times.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..");
+const fixtureRoot = resolve(repoRoot, "dev-fixtures");
+const buildRoot = resolve(repoRoot, "build");
+
+const meshviewerSource = readFileSync(resolve(fixtureRoot, "meshviewer.json"), "utf8");
+const resolved = resolveRelativeFixtureTimes(JSON.parse(meshviewerSource));
+writeFileSync(resolve(buildRoot, "meshviewer.json"), JSON.stringify(resolved, null, 2));
+
+const configSource = readFileSync(resolve(fixtureRoot, "config.json"), "utf8");
+const config = JSON.parse(configSource);
+// lib/main.ts appends "meshviewer.json" to each dataPath entry, so entries are
+// directory prefixes. Point at the sibling fixture we just wrote.
+config.dataPath = ["./"];
+writeFileSync(resolve(buildRoot, "config.json"), JSON.stringify(config, null, 2));
+
+writeFileSync(resolve(buildRoot, "PREVIEW.txt"), `Built for PR preview at ${new Date().toISOString()}\n`);

--- a/scripts/fixture-times.mjs
+++ b/scripts/fixture-times.mjs
@@ -1,0 +1,48 @@
+const relativeNowPattern = /^@now((?:[+-]\d+[smhdw])*)$/;
+
+const unitToMilliseconds = {
+  s: 1000,
+  m: 60 * 1000,
+  h: 60 * 60 * 1000,
+  d: 24 * 60 * 60 * 1000,
+  w: 7 * 24 * 60 * 60 * 1000,
+};
+
+export function parseRelativeNow(value, now) {
+  const match = relativeNowPattern.exec(value);
+
+  if (!match) {
+    return value;
+  }
+
+  const date = new Date(now);
+  const offsets = match[1].match(/[+-]\d+[smhdw]/g) ?? [];
+
+  for (const offset of offsets) {
+    const sign = offset[0] === "+" ? 1 : -1;
+    const amount = Number.parseInt(offset.slice(1, -1), 10);
+    const unit = offset.at(-1);
+
+    date.setTime(date.getTime() + sign * amount * unitToMilliseconds[unit]);
+  }
+
+  return date.toISOString();
+}
+
+export function resolveRelativeFixtureTimes(value, now = new Date()) {
+  if (typeof value === "string") {
+    return parseRelativeNow(value, now);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => resolveRelativeFixtureTimes(entry, now));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, resolveRelativeFixtureTimes(entry, now)]),
+    );
+  }
+
+  return value;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,54 +4,7 @@ import { defineConfig } from "vite";
 import { checker } from "vite-plugin-checker";
 import { VitePWA } from "vite-plugin-pwa";
 import pkg from "./package.json";
-
-const relativeNowPattern = /^@now((?:[+-]\d+[smhdw])*)$/;
-
-function parseRelativeNow(value, now) {
-  const match = relativeNowPattern.exec(value);
-
-  if (!match) {
-    return value;
-  }
-
-  const date = new Date(now);
-  const offsets = match[1].match(/[+-]\d+[smhdw]/g) ?? [];
-  const unitToMilliseconds = {
-    s: 1000,
-    m: 60 * 1000,
-    h: 60 * 60 * 1000,
-    d: 24 * 60 * 60 * 1000,
-    w: 7 * 24 * 60 * 60 * 1000,
-  };
-
-  for (const offset of offsets) {
-    const sign = offset[0] === "+" ? 1 : -1;
-    const amount = Number.parseInt(offset.slice(1, -1), 10);
-    const unit = offset.at(-1);
-
-    date.setTime(date.getTime() + sign * amount * unitToMilliseconds[unit]);
-  }
-
-  return date.toISOString();
-}
-
-function resolveRelativeFixtureTimes(value, now = new Date()) {
-  if (typeof value === "string") {
-    return parseRelativeNow(value, now);
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((entry) => resolveRelativeFixtureTimes(entry, now));
-  }
-
-  if (value && typeof value === "object") {
-    return Object.fromEntries(
-      Object.entries(value).map(([key, entry]) => [key, resolveRelativeFixtureTimes(entry, now)]),
-    );
-  }
-
-  return value;
-}
+import { resolveRelativeFixtureTimes } from "./scripts/fixture-times.mjs";
 
 function devFixturesPlugin() {
   const fixtureRoot = resolve(__dirname, "dev-fixtures");
@@ -120,39 +73,41 @@ export default defineConfig(({ command, mode }) => ({
   },
   plugins: [
     command === "serve" && mode === "fixtures" ? devFixturesPlugin() : null,
-    new VitePWA({
-      workbox: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg,ttf,woff,woff2}"],
-        navigateFallbackDenylist: [new RegExp(".*\.json")],
-      },
-      manifest: {
-        name: "Meshviewer",
-        short_name: "Meshviewer",
-        description:
-          "Meshviewer is an online visualization app to represent nodes and links on a map for Freifunk open mesh network.",
-        theme_color: "#ffffff",
-        icons: [
-          {
-            src: "pwa-64x64.png",
-            sizes: "64x64",
-            type: "image/png",
+    process.env.VITE_PREVIEW === "1"
+      ? null
+      : new VitePWA({
+          workbox: {
+            globPatterns: ["**/*.{js,css,html,ico,png,svg,ttf,woff,woff2}"],
+            navigateFallbackDenylist: [new RegExp(".*\.json")],
           },
-          {
-            src: "pwa-192x192.png",
-            sizes: "192x192",
-            type: "image/png",
+          manifest: {
+            name: "Meshviewer",
+            short_name: "Meshviewer",
+            description:
+              "Meshviewer is an online visualization app to represent nodes and links on a map for Freifunk open mesh network.",
+            theme_color: "#ffffff",
+            icons: [
+              {
+                src: "pwa-64x64.png",
+                sizes: "64x64",
+                type: "image/png",
+              },
+              {
+                src: "pwa-192x192.png",
+                sizes: "192x192",
+                type: "image/png",
+              },
+              {
+                src: "pwa-512x512.png",
+                sizes: "512x512",
+                type: "image/png",
+              },
+            ],
           },
-          {
-            src: "pwa-512x512.png",
-            sizes: "512x512",
-            type: "image/png",
+          devOptions: {
+            enabled: true,
           },
-        ],
-      },
-      devOptions: {
-        enabled: true,
-      },
-    }),
+        }),
     checker({
       // Run TypeScript checks
       typescript: true,


### PR DESCRIPTION
## Description

Three workflows render each PR to https://<owner>.github.io/<repo>/pr-preview/pr-N/ so reviewers can see the built UI without checking out the branch. Build runs on pull_request (fork-safe, read-only token) and uploads an artifact; deploy runs on workflow_run behind a pr-preview environment that requires maintainer approval, keeping fork PRs from gaining write access. Dev-fixtures are baked into the build so the preview renders against the same demo dataset as npm run dev:fixtures. PWA is disabled in preview builds (VITE_PREVIEW=1) to prevent the production service worker from intercepting preview navigations.

## Motivation and Context

This is helpful to easily showcase or visualize changes for a PR.

## How Has This Been Tested?

https://github.com/maurerle/meshviewer/pull/2#issuecomment-4416638043

## Screenshots/links:

https://maurerle.github.io/meshviewer/
https://maurerle.github.io/meshviewer/pr-preview/pr-2/

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
