### PR TITLE
[FIX] Keep selection when switching between graph and map

### DIFF
--- a/lib/gui.ts
+++ b/lib/gui.ts
@@ -105,7 +105,7 @@ export const Gui = function (language: ReturnType<typeof Language>) {
     } else {
       data = { view: "map" };
     }
-    router.fullUrl(data);
+    router.deepUrl(data);
   };
 
   buttons.appendChild(buttonToggle);

--- a/lib/utils/router.test.ts
+++ b/lib/utils/router.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { Router } from "./router.js";
+
+describe("Router.deepUrl", () => {
+  it("navigates without adding an extra hash prefix", () => {
+    const navigate = vi.fn();
+    const fakeRouter = {
+      currentState: {
+        lang: "de",
+        view: "map",
+        node: undefined,
+        link: undefined,
+        zoom: undefined,
+        lat: undefined,
+        lng: undefined,
+      },
+      getParams() {
+        return {};
+      },
+      navigate,
+      paramsToUrl: Router.prototype.paramsToUrl,
+      generateLink: Router.prototype.generateLink,
+    };
+
+    Router.prototype.deepUrl.call(fakeRouter, { view: "graph" });
+
+    expect(navigate).toHaveBeenCalledWith("/de/graph");
+  });
+});

--- a/lib/utils/router.ts
+++ b/lib/utils/router.ts
@@ -212,7 +212,8 @@ export class Router extends Navigo {
     if (e) {
       e.preventDefault();
     }
-    this.navigate(this.generateLink(data));
+    const target = this.generateLink(data);
+    this.navigate(target.startsWith("#") ? target.slice(1) : target);
   }
 
   getLang() {


### PR DESCRIPTION
## Description

When selecting a node ans switching between graph/map view, the node selection was lost. This fixes it.

Also `router.fullUrl` was fixed to not add an extra hash to the path. The same issue was already fixed in an older commit for switching the language but not for `router.fullUrl`. And I added a test for this ;-)

## Motivation and Context

It's was a bug. Now it's fixed.

## How Has This Been Tested?

Fixefox, Unit Test

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
