### PR TITLE
[Feature] Robust parsing of nodelist

### DIFF
--- a/dev-fixtures/meshviewer.json
+++ b/dev-fixtures/meshviewer.json
@@ -335,6 +335,15 @@
       "target_addr": "02:11:22:33:44:08",
       "source_tq": 0.95,
       "target_tq": 0.93
+    },
+    {
+      "type": "wifi24",
+      "source": "1004",
+      "target": "missing.a99",
+      "source_addr": "02:11:22:33:44:02",
+      "target_addr": "02:11:22:33:44:99",
+      "source_tq": 0.42,
+      "target_tq": 0.17
     }
   ]
 }

--- a/dev-fixtures/meshviewer.json
+++ b/dev-fixtures/meshviewer.json
@@ -306,6 +306,19 @@
         "enabled": false,
         "branch": "stable"
       }
+    },
+    {
+      "node_id": "sparse.a77",
+      "hostname": "Pollux",
+      "domain": "lab",
+      "firstseen": "@now-3d",
+      "lastseen": "@now-2h",
+      "is_online": false,
+      "location": {
+        "latitude": 52.5061,
+        "longitude": 13.3958
+      },
+      "is_gateway": false
     }
   ],
   "links": [

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -7,6 +7,7 @@ import { Gui } from "./gui.js";
 import { Language } from "./utils/language.js";
 import * as helper from "./utils/helper.js";
 import { Link } from "./utils/node.js";
+import { resolveValidLinks } from "./mainDataUtils.js";
 
 export const main = () => {
   function handleData(data: { links: Link[]; nodes: Node[]; timestamp: string }[]) {
@@ -44,10 +45,9 @@ export const main = () => {
       nodeDict[node.node_id] = node;
     });
 
-    links.forEach(function (link) {
-      link.source = nodeDict[link.source];
-      link.target = nodeDict[link.target];
+    let validLinks = resolveValidLinks(links, nodeDict);
 
+    validLinks.forEach(function (link) {
       link.id = [link.source.node_id, link.target.node_id].join("-");
       link.source.neighbours.push({ node: link.target, link: link });
       link.target.neighbours.push({ node: link.source, link: link });
@@ -73,7 +73,7 @@ export const main = () => {
         new: newnodes,
         lost: lostnodes,
       },
-      links: links,
+      links: validLinks,
       nodeDict: nodeDict,
     };
   }

--- a/lib/mainDataUtils.test.ts
+++ b/lib/mainDataUtils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolveValidLinks } from "./mainDataUtils.js";
+
+describe("resolveValidLinks", () => {
+  it("keeps only links with resolvable source and target nodes", () => {
+    const nodeA = { node_id: "1004", hostname: "Vega" };
+    const nodeB = { node_id: "1005", hostname: "Rigel" };
+    const links = [
+      { type: "wifi24", source: "1004", target: "1005" },
+      { type: "wifi24", source: "1004", target: "missing.a99" },
+    ];
+
+    const validLinks = resolveValidLinks(links, {
+      [nodeA.node_id]: nodeA,
+      [nodeB.node_id]: nodeB,
+    });
+
+    expect(validLinks).toHaveLength(1);
+    expect(validLinks[0].source).toBe(nodeA);
+    expect(validLinks[0].target).toBe(nodeB);
+  });
+});

--- a/lib/mainDataUtils.ts
+++ b/lib/mainDataUtils.ts
@@ -1,0 +1,29 @@
+export interface LinkWithEndpointIds<TNode> {
+  source: string | TNode;
+  target: string | TNode;
+}
+
+export function resolveValidLinks<TNode extends { node_id: string }, TLink extends LinkWithEndpointIds<TNode>>(
+  links: TLink[],
+  nodeDict: Record<string, TNode>,
+): Array<TLink & { source: TNode; target: TNode }> {
+  let validLinks: Array<TLink & { source: TNode; target: TNode }> = [];
+
+  links.forEach(function (link) {
+    const sourceId = typeof link.source === "string" ? link.source : link.source.node_id;
+    const targetId = typeof link.target === "string" ? link.target : link.target.node_id;
+    const source = nodeDict[sourceId];
+    const target = nodeDict[targetId];
+
+    if (!source || !target) {
+      return;
+    }
+
+    const resolvedLink = link as TLink & { source: TNode; target: TNode };
+    resolvedLink.source = source;
+    resolvedLink.target = target;
+    validLinks.push(resolvedLink);
+  });
+
+  return validLinks;
+}

--- a/lib/proportions.ts
+++ b/lib/proportions.ts
@@ -53,7 +53,7 @@ const statusFieldMapping: Record<string, MappingEntry> = {
   "node.update": {
     keys: ["autoupdater"],
     nodeValueModifier: function (d: any) {
-      if (d.enabled) {
+      if (d && d.enabled) {
         return d.branch;
       }
       return _.t("node.deactivated");

--- a/lib/utils/node.test.ts
+++ b/lib/utils/node.test.ts
@@ -1,0 +1,65 @@
+import moment from "moment";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("snabbdom", () => ({
+  h: (...args: any[]) => ({ args }),
+}));
+
+vi.mock("leaflet", () => ({}));
+
+vi.mock("./language.js", () => ({
+  _: {
+    t: (key: string, params?: { branch?: string }) => (params?.branch ? `${key}:${params.branch}` : key),
+  },
+}));
+
+import nodef from "./node.js";
+
+describe("node utils with sparse nodes", () => {
+  it("returns undefined for missing optional node attributes instead of crashing", () => {
+    const sparseNode = {
+      node_id: "sparse.a77",
+      hostname: "Pollux",
+      firstseen: moment.utc("2026-05-04T18:00:00Z").local(),
+      lastseen: moment.utc("2026-05-06T22:00:00Z").local(),
+      is_online: false,
+      location: {
+        latitude: 52.5061,
+        longitude: 13.3958,
+      },
+      neighbours: [],
+      is_gateway: false,
+    } as any;
+
+    expect(nodef.showFirmware(sparseNode)).toBeUndefined();
+    expect(nodef.showUptime(sparseNode)).toBeUndefined();
+    expect(nodef.showLoad(sparseNode)).toBeUndefined();
+    expect(nodef.showRAM(sparseNode)).toBeUndefined();
+    expect(nodef.showIPs(sparseNode)).toBeUndefined();
+    expect(nodef.showAutoupdate(sparseNode)).toBeUndefined();
+  });
+
+  it("returns undefined for null optional node attributes from live data", () => {
+    const nullNode = {
+      node_id: "1450",
+      hostname: "Sumo (1450)",
+      firstseen: moment.utc("2026-03-28T23:42:11Z").local(),
+      lastseen: moment.utc("2026-05-08T19:12:37Z").local(),
+      is_online: true,
+      location: {
+        latitude: 51.0,
+        longitude: 12.0,
+      },
+      neighbours: [],
+      is_gateway: false,
+      nproc: 1,
+      uptime: null,
+      loadavg: null,
+      memory_usage: null,
+    } as any;
+
+    expect(nodef.showUptime(nullNode)).toBeUndefined();
+    expect(nodef.showLoad(nullNode)).toBeUndefined();
+    expect(nodef.showRAM(nullNode)).toBeUndefined();
+  });
+});

--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -131,6 +131,9 @@ self.showFirmware = function showFirmware(node: Node) {
 };
 
 self.showUptime = function showUptime(node: Node) {
+  if (node.uptime == null) {
+    return undefined;
+  }
   return moment.utc(node.uptime).local().fromNow(true);
 };
 
@@ -139,10 +142,16 @@ self.showFirstSeen = function showFirstSeen(node: Node) {
 };
 
 self.showLoad = function showLoad(node: Node) {
+  if (node.loadavg == null) {
+    return undefined;
+  }
   return showBar(node.loadavg.toFixed(2), node.loadavg / (node.nproc || 1), node.loadavg >= node.nproc);
 };
 
 self.showRAM = function showRAM(node: Node) {
+  if (node.memory_usage == null) {
+    return undefined;
+  }
   return showBar(Math.round(node.memory_usage * 100) + " %", node.memory_usage, node.memory_usage >= 0.8);
 };
 
@@ -208,6 +217,9 @@ self.showClients = function showClients(node: Node) {
 };
 
 self.showIPs = function showIPs(node: Node) {
+  if (!node.addresses) {
+    return undefined;
+  }
   let string = [];
   let ips = node.addresses;
   ips.sort();
@@ -226,6 +238,9 @@ self.showIPs = function showIPs(node: Node) {
 };
 
 self.showAutoupdate = function showAutoupdate(node: Node) {
+  if (!node.autoupdater) {
+    return undefined;
+  }
   return node.autoupdater.enabled
     ? _.t("node.activated", { branch: node.autoupdater.branch })
     : _.t("node.deactivated");


### PR DESCRIPTION
## Description

The map is very sensitive to incomplete node lists (missing attributes in nodes, missing targets in links). This makes it more robust.

* Fixes #363
* Fixes #364 

## Motivation and Context

We have several node sources (historically Leipzig Freifunk uses at least 3 kinds of firmwares/mesh types). This leads to nodes that do not have all attributes that meshviewer expects. The change makes meshviewer a bit more robust by null-checking node attributes before accessing it.

We also share infrastructure with Freifunk Dresden and filter the map by community. That can lead to situations where only one end of a link is on the map. Therefore the link list is now checked for consistency to avoid startup errors of the map.

## How Has This Been Tested?

Firefox (I added a bunch of incomplete nodes to the demo data). Unit tests (moved critical helper functions to extra files to make it better testable).

Node "Pollux" in the demo data is a demo node with lot of missing properties.

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
