### PR TITLE
[FIX] language switch loses route on reload

### DIFF
--- a/lib/utils/router.test.ts
+++ b/lib/utils/router.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Router } from "./router.js";
 
 describe("Router.deepUrl", () => {
@@ -25,5 +25,58 @@ describe("Router.deepUrl", () => {
     Router.prototype.deepUrl.call(fakeRouter, { view: "graph" });
 
     expect(navigate).toHaveBeenCalledWith("/de/graph");
+  });
+});
+
+describe("Router.customRoute language change", () => {
+  const hashSetter = vi.fn<(v: string) => void>();
+  const reload = vi.fn<() => void>();
+
+  beforeEach(() => {
+    hashSetter.mockReset();
+    reload.mockReset();
+    vi.stubGlobal("location", {
+      get hash() {
+        return "";
+      },
+      set hash(v: string) {
+        hashSetter(v);
+      },
+      reload,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rebuilds the hash from currentState when navigate omits the # prefix", () => {
+    const fakeRouter = {
+      state: { lang: "de", view: "map" },
+      currentState: {},
+      language: { getLocale: (l: string) => l },
+      targets: [],
+      init: true,
+      objects: { nodes: { all: [], lost: [], new: [], offline: [], online: [] }, links: [], nodeDict: {} },
+      view: vi.fn(),
+      gotoNode: vi.fn(),
+      gotoLink: vi.fn(),
+      resetView: vi.fn(),
+      getParams: () => ({}),
+      paramsToUrl: Router.prototype.paramsToUrl,
+      generateLink: Router.prototype.generateLink,
+    };
+
+    // Mimic what Navigo passes to the handler after deepUrl({lang: "en"})
+    // navigates to "/en/map" — note hashString is "" because there is no "#".
+    const match = {
+      data: ["en", "map", undefined, undefined, undefined, undefined, undefined],
+      hashString: "",
+    };
+
+    Router.prototype.customRoute.call(fakeRouter as never, match as never);
+
+    expect(hashSetter).toHaveBeenCalledWith("/en/map");
+    expect(reload).toHaveBeenCalled();
   });
 });

--- a/lib/utils/router.ts
+++ b/lib/utils/router.ts
@@ -107,8 +107,7 @@ export class Router extends Navigo {
 
     if (lang && lang !== this.state.lang && lang === this.language.getLocale(lang)) {
       console.debug("Language change reload");
-      const prefix = match.hashString.startsWith("/") ? "" : "/";
-      location.hash = prefix + match.hashString;
+      location.hash = this.generateLink().substring(1);
       location.reload();
     }
 


### PR DESCRIPTION

## Description

fixes 3a64554

Since commit merge of #368, `deepUrl({lang})` calls `navigate("/en/map")` instead of `navigate("#/en/map")`. Without the leading "#", Navigo leaves `match.hashString` empty.

`Router.customRoute` was relying on `match.hashString` to reconstruct the URL before reloading the page on a language change, so it ended up doing `location.hash = "/"` and the reload picked up no language from the URL — the locale silently fell back to the browser default.

Rebuild the reload URL from `currentState` via `generateLink()` instead, which is already populated by the time the lang-change branch runs and is independent of how navigate() was originally invoked.

## How Has This Been Tested?

language settings work fine now

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
