### PR TITLE
[FEATURE] use updated svgs from freifunk device-pictures

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -177,7 +177,7 @@ TODO
 Nodes can display a picture of the device type. These need to be provided as svg pictures. There is an existing repository with these pictures (see source below).
 
 ```json
-  "devicePictures": "https://map.aachen.freifunk.net/pictures-svg/{MODEL_NORMALIZED}.svg",
+  "devicePictures": "https://freifunk.github.io/device-pictures/pictures-svg/{MODEL_NORMALIZED}.svg",
   "devicePicturesSource": "<a href='https://github.com/freifunk/device-pictures'>https://github.com/freifunk/device-pictures</a>",
   "devicePicturesLicense": "CC-BY-NC-SA 4.0",
 ```

--- a/config.example.json
+++ b/config.example.json
@@ -70,7 +70,7 @@
       "title": "Bild der Wochenstatistik"
     }
   ],
-  "devicePictures": "https://map.aachen.freifunk.net/pictures-svg/{MODEL_NORMALIZED}.svg",
+  "devicePictures": "https://freifunk.github.io/device-pictures/pictures-svg/{MODEL_NORMALIZED}.svg",
   "devicePicturesSource": "<a href='https://github.com/freifunk/device-pictures'>https://github.com/freifunk/device-pictures</a>",
   "devicePicturesLicense": "CC-BY-NC-SA 4.0",
   "node_custom": "/[^a-z0-9\\-\\.]/ig",

--- a/lib/config_default.ts
+++ b/lib/config_default.ts
@@ -479,7 +479,7 @@ export const config: Config = {
   linkInfos: [],
   nodeInfos: [],
   node_custom: "",
-  devicePictures: "https://map.aachen.freifunk.net/pictures-svg/{MODEL_NORMALIZED}.svg",
+  devicePictures: "https://freifunk.github.io/device-pictures/pictures-svg/{MODEL_NORMALIZED}.svg",
   devicePicturesSource:
     "<a href='https://github.com/freifunk/device-pictures'>https://github.com/freifunk/device-pictures</a>",
   devicePicturesLicense: "CC-BY-NC-SA 4.0",


### PR DESCRIPTION
## Description

This uses updated SVGs from the https://github.com/freifunk/device-pictures repository

## Motivation and Context

fixes #379 

## How Has This Been Tested?

looking at a config in `npm run dev` and validating the build using `npm run build && python -m http.server -d build`

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
