### PR TITLE
[BUGFIX] load: deep-merge user config.json onto defaults

### DIFF
--- a/lib/load.ts
+++ b/lib/load.ts
@@ -1,6 +1,24 @@
 import { config as defaultConfig } from "./config_default.js";
 import { main } from "./main.js";
 
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// Recursively overlay the user-supplied config.json onto the built-in defaults.
+// config.json is entirely user-controlled, so we cannot rely on it to be
+// complete: any key it omits must keep its default. Nested objects merge key by
+// key; arrays and primitives replace outright.
+const deepMerge = <T>(defaults: T, overrides: unknown): T => {
+  if (!isPlainObject(defaults) || !isPlainObject(overrides)) {
+    return overrides === undefined ? defaults : (overrides as T);
+  }
+  const result: Record<string, unknown> = { ...defaults };
+  for (const key of Object.keys(overrides)) {
+    result[key] = deepMerge(defaults[key], overrides[key]);
+  }
+  return result as T;
+};
+
 export const load = async () => {
   const configResponse = await fetch("config.json");
   if (!configResponse.ok) {
@@ -16,6 +34,6 @@ export const load = async () => {
     return;
   }
   const config = await configResponse.json();
-  globalThis.config = Object.assign(defaultConfig, config);
+  globalThis.config = deepMerge(defaultConfig, config);
   main();
 };


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

As the config.json is user-controlled, it cannot be assumed to contain every key. It was merged onto the built-in defaults with a shallow Object.assign(), which replaces whole nested objects rather than the individual keys. An operator config that overrides forceGraph therefore drops every sibling default it does not restate.

config_default.ts later grew forceGraph.otherLinkColor and forceGraph.nodeUplinkColor, used to recolour "other"-type links and uplink nodes in the graph view. Any operator forceGraph block predating those keys silently resolves them to undefined, and drawLink() hands that undefined to the canvas gradient:

  Uncaught SyntaxError: Failed to execute 'addColorStop' on 'CanvasGradient':
  The value provided ('undefined') could not be parsed as a color.

The throw aborts the entire redraw, so it recurs on every animation frame, flooding the console with lots of errors with the graph being broken.

Merge the user config recursively instead: nested objects are merged key by key so an omitted key keeps its default, while arrays and primitives still replace outright. Defaults now come from code rather than depending on the user-supplied file being complete.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

https://map.ffmuc.net/#/en/graph

## Screenshots/links:

Before:
<img width="687" height="633" alt="image" src="https://github.com/user-attachments/assets/8bea247b-0f3a-453e-9bbc-dc8d85ae67cd" />

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
