### PR TITLE
[FEATURE] preview: use PR title as the site headline

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -20,6 +20,8 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: node scripts/build-preview-fixtures.mjs
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
       - run: echo "${{ github.event.pull_request.number }}" > build/.pr-number
       - uses: actions/upload-artifact@v7
         with:

--- a/scripts/build-preview-fixtures.mjs
+++ b/scripts/build-preview-fixtures.mjs
@@ -17,6 +17,12 @@ const config = JSON.parse(configSource);
 // lib/main.ts appends "meshviewer.json" to each dataPath entry, so entries are
 // directory prefixes. Point at the sibling fixture we just wrote.
 config.dataPath = ["./"];
+// On PR previews, surface the PR title as the site headline (config.siteName
+// renders into the <h1> via textContent, so it is safe from injection).
+const prTitle = (process.env.PR_TITLE ?? "").trim();
+if (prTitle) {
+  config.siteName = prTitle;
+}
 writeFileSync(resolve(buildRoot, "config.json"), JSON.stringify(config, null, 2));
 
 for (const fixture of ["grafana-node.json", "grafana-link.json", "grafana-global.json"]) {


### PR DESCRIPTION
## Description

The PR preview deployment hard-coded "Meshviewer Local Fixtures" as the site headline (config.siteName). Pass the PR title into the fixture build via the PR_TITLE env var and override config.siteName with it, so each preview is identifiable. Falls back to the default when empty. The value is passed through env (not inline interpolation) and rendered via textContent, so it is safe from injection.

## Motivation and Context

The previous name in the deployment was not meaningful

## How Has This Been Tested?

In this PR deployment.

## Screenshots/links:

<img width="1550" height="854" alt="image" src="https://github.com/user-attachments/assets/5f42daf5-c601-4b2f-8ace-67aea08d3218" />

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
