### PR TITLE
FIX: vector map layers + code-split maplibre-gl out of the main bundle

### DIFF
--- a/lib/gui.ts
+++ b/lib/gui.ts
@@ -25,7 +25,12 @@ export const Gui = function (language: ReturnType<typeof Language>) {
   const self: { setData: (data: ObjectsLinksAndNodes) => void } = {
     setData: () => {},
   };
-  let content: ReturnType<typeof Map> | ReturnType<typeof ForceGraph> | null = null;
+  type Content = Awaited<ReturnType<typeof Map>> | ReturnType<typeof ForceGraph>;
+  let content: Content | null = null;
+  // Bumped on every add/remove. An in-flight async addContent that finishes
+  // after the user has toggled the view checks this to avoid mounting stale
+  // content over whatever is now showing.
+  let contentVersion = 0;
   let contentDiv: HTMLDivElement;
   let router = window.router;
   let config = window.config;
@@ -41,6 +46,7 @@ export const Gui = function (language: ReturnType<typeof Language>) {
   fanoutUnfiltered.add(fanout);
 
   function removeContent() {
+    contentVersion++;
     if (!content) {
       return;
     }
@@ -53,19 +59,23 @@ export const Gui = function (language: ReturnType<typeof Language>) {
     content = null;
   }
 
-  function addContent(mapViewComponent: typeof Map | typeof ForceGraph) {
+  async function addContent(mapViewComponent: typeof Map | typeof ForceGraph) {
     removeContent();
-
-    content = mapViewComponent(linkScale, sidebar, buttons);
+    const version = contentVersion;
+    const newContent = await mapViewComponent(linkScale, sidebar, buttons);
+    if (version !== contentVersion) {
+      newContent.destroy();
+      return;
+    }
+    content = newContent;
     content.render(contentDiv);
-
     fanout.add(content);
     router.addTarget(content);
   }
 
   function mkView(mapViewComponent: typeof Map | typeof ForceGraph) {
     return function () {
-      addContent(mapViewComponent);
+      void addContent(mapViewComponent);
     };
   }
 

--- a/lib/gui.ts
+++ b/lib/gui.ts
@@ -75,7 +75,10 @@ export const Gui = function (language: ReturnType<typeof Language>) {
 
   function mkView(mapViewComponent: typeof Map | typeof ForceGraph) {
     return function () {
-      void addContent(mapViewComponent);
+      // Return the promise so the router can await the (possibly async) content
+      // mount before it applies the view — otherwise resetView/gotoNode run
+      // before the target is registered and the initial setView is lost.
+      return addContent(mapViewComponent);
     };
   }
 

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -3,7 +3,7 @@ import * as L from "leaflet";
 import { ClientLayer } from "./map/clientlayer.js";
 import { LabelLayer } from "./map/labellayer.js";
 import { Button } from "./map/button.js";
-import { maplibreGL } from "./map/maplibre-layer.js";
+import { loadMaplibreGL } from "./map/maplibre-layer.js";
 import "./map/activearea.js";
 import { Sidebar } from "./sidebar.js";
 import { LatLng } from "leaflet";
@@ -17,7 +17,11 @@ let options = {
   minZoom: 0,
 };
 
-export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typeof Sidebar>, buttons: HTMLElement) {
+export const Map = async function (
+  linkScale: (t: any) => any,
+  sidebar: ReturnType<typeof Sidebar>,
+  buttons: HTMLElement,
+) {
   const self: {
     setData: (data: ObjectsLinksAndNodes) => void;
     resetView: () => void;
@@ -89,12 +93,14 @@ export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typ
     return a.config.order - b.config.order;
   });
 
+  const maplibreGL = config.mapLayers.some((l) => l.type === "vector") ? await loadMaplibreGL() : undefined;
+
   let layers = config.mapLayers.map(function (layer) {
     return {
       name: layer.name,
       layer:
         layer.type == "vector"
-          ? maplibreGL({
+          ? maplibreGL!({
               style: layer.url,
               attributionControl: { customAttribution: layer.config.attribution },
               maxZoom: layer.config.maxZoom,

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -1,9 +1,9 @@
 import * as L from "leaflet";
-import "@maplibre/maplibre-gl-leaflet";
 
 import { ClientLayer } from "./map/clientlayer.js";
 import { LabelLayer } from "./map/labellayer.js";
 import { Button } from "./map/button.js";
+import { maplibreGL } from "./map/maplibre-layer.js";
 import "./map/activearea.js";
 import { Sidebar } from "./sidebar.js";
 import { LatLng } from "leaflet";
@@ -94,7 +94,7 @@ export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typ
       name: layer.name,
       layer:
         layer.type == "vector"
-          ? L.maplibreGL({
+          ? maplibreGL({
               style: layer.url,
               attributionControl: { customAttribution: layer.config.attribution },
               maxZoom: layer.config.maxZoom,

--- a/lib/map/maplibre-layer.ts
+++ b/lib/map/maplibre-layer.ts
@@ -1,0 +1,17 @@
+import "@maplibre/maplibre-gl-leaflet";
+import * as L from "leaflet";
+
+// @maplibre/maplibre-gl-leaflet is a UMD package that adds `L.maplibreGL` to
+// leaflet via a runtime side effect. Under vite v8's rolldown bundler,
+// `import * as L from "leaflet"` is compiled to a namespace whose property
+// getters are set up at snapshot time. The maplibre side effect runs *after*
+// that snapshot, so the new `maplibreGL` property is not reachable through
+// the namespace (`L.maplibreGL` is undefined and the runtime throws
+// "L.maplibreGL is not a function"). The snapshot's `default` slot is a
+// direct value reference to the live module-exports object that the side
+// effect actually mutates, so we go through it.
+const liveL = (L as unknown as { default: typeof L & { maplibreGL: typeof L.maplibreGL } }).default;
+
+export function maplibreGL(options: Parameters<typeof L.maplibreGL>[0]): L.MaplibreGL {
+  return liveL.maplibreGL(options);
+}

--- a/lib/map/maplibre-layer.ts
+++ b/lib/map/maplibre-layer.ts
@@ -1,17 +1,25 @@
-import "@maplibre/maplibre-gl-leaflet";
 import * as L from "leaflet";
 
-// @maplibre/maplibre-gl-leaflet is a UMD package that adds `L.maplibreGL` to
-// leaflet via a runtime side effect. Under vite v8's rolldown bundler,
-// `import * as L from "leaflet"` is compiled to a namespace whose property
-// getters are set up at snapshot time. The maplibre side effect runs *after*
-// that snapshot, so the new `maplibreGL` property is not reachable through
-// the namespace (`L.maplibreGL` is undefined and the runtime throws
-// "L.maplibreGL is not a function"). The snapshot's `default` slot is a
-// direct value reference to the live module-exports object that the side
-// effect actually mutates, so we go through it.
-const liveL = (L as unknown as { default: typeof L & { maplibreGL: typeof L.maplibreGL } }).default;
+type MaplibreGLFactory = typeof L.maplibreGL;
+type LiveL = typeof L & { maplibreGL: MaplibreGLFactory };
 
-export function maplibreGL(options: Parameters<typeof L.maplibreGL>[0]): L.MaplibreGL {
-  return liveL.maplibreGL(options);
+// maplibre-gl is ~1MB minified — keep it out of the main bundle by loading it
+// dynamically on demand. Vector layers are the only consumer.
+let cached: Promise<MaplibreGLFactory> | undefined;
+
+export function loadMaplibreGL(): Promise<MaplibreGLFactory> {
+  if (!cached) {
+    // The package is a UMD that adds `L.maplibreGL` to leaflet via a side
+    // effect. Under vite's rolldown bundler, `import * as L from "leaflet"`
+    // gives us a namespace whose getters are set up at snapshot time, so the
+    // newly-attached `maplibreGL` is not visible through `L.maplibreGL`. The
+    // snapshot's `default` slot is a direct value reference to the live
+    // module-exports object that the side effect actually mutates, so we go
+    // through it.
+    cached = import("@maplibre/maplibre-gl-leaflet").then(() => {
+      const liveL = (L as unknown as { default: LiveL }).default;
+      return liveL.maplibreGL.bind(liveL);
+    });
+  }
+  return cached;
 }

--- a/lib/utils/router.ts
+++ b/lib/utils/router.ts
@@ -90,16 +90,18 @@ export class Router extends Navigo {
     }
   }
 
-  view(data: { view: string }) {
+  async view(data: { view: string }) {
     const view = this.views[data.view];
     if (view) {
-      view();
+      // The view factory may be async (the map lazy-loads maplibre-gl). Await
+      // it so the target is registered before resetView applies the view.
+      await view();
       this.state.view = data.view;
       this.resetView();
     }
   }
 
-  customRoute(match?: Match) {
+  async customRoute(match?: Match) {
     const d = match?.data as RouteData;
     const lang = routeGroup(d, 0);
     let viewValue: "map" | "graph" | string | undefined = routeGroup(d, 1);
@@ -129,7 +131,7 @@ export class Router extends Navigo {
       if (!viewValue) {
         viewValue = this.state.view;
       }
-      this.view({ view: viewValue });
+      await this.view({ view: viewValue });
       this.init = true;
     }
 
@@ -167,7 +169,7 @@ export class Router extends Navigo {
         // lang, viewValue, node, link, zoom, lat, lon
         MESHVIEWER_ROUTE_PATTERN,
         (match?: Match) => {
-          this.customRoute(match);
+          void this.customRoute(match);
         },
       )
       // Default response

--- a/vite.config.js
+++ b/vite.config.js
@@ -83,6 +83,11 @@ export default defineConfig(({ command, mode }) => ({
         offline: resolve(__dirname, "offline.html"),
       },
     },
+    // The main bundle sits comfortably under 500 kB. The only remaining
+    // large chunk is the dynamically-imported maplibre-gl bundle (~1 MB,
+    // only loaded on demand for vector layers), so raise the threshold
+    // slightly above its size rather than nagging on every build.
+    chunkSizeWarningLimit: 1100,
   },
   plugins: [
     command === "serve" && mode === "fixtures" ? devFixturesPlugin() : null,
@@ -91,6 +96,11 @@ export default defineConfig(({ command, mode }) => ({
       : new VitePWA({
           workbox: {
             globPatterns: ["**/*.{js,css,html,ico,png,svg,ttf,woff,woff2}"],
+            // The maplibre-gl chunk (~1 MB) is only fetched when a vector
+            // map layer is configured. Don't waste bandwidth precaching it
+            // on every install — the service worker can still serve it
+            // from runtime cache when it is actually requested.
+            globIgnores: ["**/leaflet-maplibre-gl-*.js"],
             navigateFallbackDenylist: [new RegExp(".*\.json")],
           },
           manifest: {


### PR DESCRIPTION
  ## Summary

  Vector (maplibre) map layers were broken under the new vite/rolldown bundler, and
  maplibre-gl was bloating the main bundle for everyone even though only vector
  configs use it. This branch fixes the vector layers, lazy-loads maplibre-gl, and
  fixes a gray-map regression that the lazy-loading introduced.

  ## Changes

  ### 1. Vector layers throw `L.maplibreGL is not a function`
  `@maplibre/maplibre-gl-leaflet` is a UMD package that attaches `L.maplibreGL` to
  leaflet via a runtime side effect. Under vite's rolldown bundler,
  `import * as L from "leaflet"` snapshots the namespace's getters before that side
  effect runs, so `L.maplibreGL` is never visible and any `"type": "vector"` layer
  crashed map setup. Routed through the snapshot's `default` slot (a live reference
  to the mutated module exports) in a small `map/maplibre-layer.ts` wrapper.

  ### 2. Code-split maplibre-gl out of the main bundle
  maplibre-gl is ~1 MB minified (~70% of the old main bundle) but only needed for
  vector layers — the minority case. It's now `await import(...)`-ed on demand and
  excluded from the PWA precache (workbox still caches it at runtime if requested).

  | bundle    | before  | after            |
  |-----------|---------|------------------|
  | main      | 1390 kB | 393 kB           |
  | maplibre  | —       | 997 kB (on demand) |
  | precache  | 1719 kB | 745 kB           |

  ### 3. Fix gray map / "Set map center and zoom first." regression
  Lazy-loading made the `Map` factory `async`, so `gui.ts`'s `addContent` registered
  the map target only *after* `await mapViewComponent(...)` resolved — a microtask
  after the router applied the view. `mkView` discarded the promise and the router
  ran `resetView()`/`gotoNode()` synchronously, before the target existed, so the
  initial `map.setView()` never reached the map. Leaflet's `_loaded` stayed false,
  the map rendered gray with no tiles, and the next drag fired
  `dragend → saveView → getCenter`, throwing *"Set map center and zoom first."*

  Fixed by threading the mount promise back: `mkView` returns `addContent(...)`, and
  `Router.view()` / `Router.customRoute()` are now `async` and `await` it, so the
  view is applied after the target is registered. Affects **all** map layers, not
  just vector ones.

  ## Testing
  - `npm run build` (incl. typecheck) and `npm run test:unit` (10 tests) pass.
  - Headless verification against `dev:fixtures`: before the view fix the map loaded
    **0 tiles** (gray); after, **24 tiles** render and a node click + map drag
    produce no console errors.
  - Vector-layer path verified building with a `"type": "vector"` layer and loading
    in headless chromium — reaches maplibre-gl's WebGL init with no bundler error.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
