### PR TITLE
Support IPv4 Node links

### DIFF
--- a/lib/utils/node.test.ts
+++ b/lib/utils/node.test.ts
@@ -39,6 +39,21 @@ describe("node utils with sparse nodes", () => {
     expect(nodef.showAutoupdate(sparseNode)).toBeUndefined();
   });
 
+  it("brackets IPv6 but not IPv4 addresses in node web-interface links", () => {
+    const node = { addresses: ["10.200.7.237", "2001:db8::1", "fe80::1"] } as any;
+
+    const td = nodef.showIPs(node) as any;
+    const parts: any[] = td.args[1];
+    const anchors = parts.filter((p) => p && p.args && p.args[0] === "a");
+    const hrefs = anchors.map((a) => a.args[1].props.href);
+    const linkedIps = anchors.map((a) => a.args[2]);
+
+    // IPv4: no brackets; IPv6: brackets; link-local (fe80::) not linked at all
+    expect(hrefs).toContain("http://10.200.7.237/");
+    expect(hrefs).toContain("http://[2001:db8::1]/");
+    expect(linkedIps).not.toContain("fe80::1");
+  });
+
   it("returns undefined for null optional node attributes from live data", () => {
     const nullNode = {
       node_id: "1450",

--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -216,10 +216,12 @@ const self = {
         parts.push(h("br"));
       }
 
-      if (ip.indexOf("fe80:") !== 0) {
-        parts.push(h("a", { props: { href: "http://[" + ip + "]/", target: "_blank" } }, ip));
-      } else {
+      if (ip.indexOf("fe80:") === 0) {
         parts.push(ip);
+      } else {
+        // Bracket notation is only valid for IPv6 literals; IPv4 must stay unbracketed
+        const host = ip.indexOf(":") !== -1 ? "[" + ip + "]" : ip;
+        parts.push(h("a", { props: { href: "http://" + host + "/", target: "_blank" } }, ip));
       }
     });
     return h("td", parts);


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

Meshviewer assumes all nodes have IPv6 addresses and renders links as http://[$IP]/. For IPv4, the brackets must be ommitted.

## Motivation and Context

We have an IPv4 Network ^^

## How Has This Been Tested?

Unit test

## Screenshots/links:

<img width="516" height="81" alt="grafik" src="https://github.com/user-attachments/assets/5dd050ff-4ea8-46e6-aa0c-514f5eb22559" />

## Checklist:

- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
