### PR TITLE
Add embed.js to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN npm run lint && npm run build
 FROM nginx:1.31.2-alpine
 COPY --from=build /code/build/ /usr/share/nginx/html
 COPY --from=build /code/config.example.json /usr/share/nginx/html/
+COPY --from=build /code/embed/embed.js /usr/share/nginx/html/
 EXPOSE 80


### PR DESCRIPTION
## Description

Adds embed.js to the docker image

## Motivation and Context

Deliver embed.js along with meshviewer, so that embedding pages can refer to the version that blongs to this meshviewer version.

## How Has This Been Tested?

Only reviewed (just adds 1 file to the docker image)

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
