### PR TITLE
utils: extract getDomainName() for domain display-name lookup

### DIFF
--- a/dev-fixtures/config.json
+++ b/dev-fixtures/config.json
@@ -47,6 +47,7 @@
     [52.54, 13.0],
     [52.48, 13.45]
   ],
+  "domainNames": [{ "domain": "lab", "name": "Lab Domain" }],
   "mapLayers": [
     {
       "name": "CartoDB",

--- a/lib/proportions.ts
+++ b/lib/proportions.ts
@@ -5,7 +5,7 @@ import { DataDistributor, Filter, GenericFilter, ObjectsLinksAndNodes } from "./
 import { GenericNodeFilter } from "./filters/genericnode.js";
 import * as helper from "./utils/helper.js";
 import { _ } from "./utils/language.js";
-import { Node } from "./utils/node.js";
+import { getDomainName, Node } from "./utils/node.js";
 import { compare } from "./utils/version.js";
 import { createChartVNode } from "./infobox/chart.js";
 
@@ -80,17 +80,7 @@ const statusFieldMapping: Record<StatusFieldKey, MappingEntry> = {
   },
   "node.domain": {
     keys: ["domain"],
-    nodeValueModifier: function (d: any) {
-      if (window.config.domainNames) {
-        window.config.domainNames.some(function (t) {
-          if (d === t.domain) {
-            d = t.name;
-            return true;
-          }
-        });
-      }
-      return d;
-    },
+    nodeValueModifier: getDomainName,
   },
 };
 

--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -76,6 +76,14 @@ function showBar(value: string, width: number, warning: boolean) {
   ]);
 }
 
+export function getDomainName(domain: string): string {
+  const domainNames = window.config.domainNames;
+  if (!domainNames) return domain;
+
+  const match = domainNames.find((entry) => entry.domain === domain);
+  return match ? match.name : domain;
+}
+
 const self = {
   showStatus(node: Node) {
     return h(
@@ -143,18 +151,7 @@ const self = {
   },
 
   showDomain(node: Node) {
-    let domainTitle = node.domain;
-    const config = window.config;
-    if (config.domainNames) {
-      config.domainNames.some(function (domain) {
-        if (domainTitle === domain.domain) {
-          domainTitle = domain.name;
-          return true;
-        }
-        return false;
-      });
-    }
-    return domainTitle;
+    return node.domain === undefined ? undefined : getDomainName(node.domain);
   },
 
   countLocalClients(node: Node, visited: Record<string, number> = {}) {


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

Node.showDomain and proportions' node.domain modifier both inlined the same scan over config.domainNames to turn a domain slug into its display name. Extract a shared getDomainName() helper and reuse it in both.

## Motivation and Context

I noticed this while working to improve the client-side rendered graphs.

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
