### PR TITLE
fix(charts): adaptive x-axis tick format based on visible span

### DIFF
--- a/lib/infobox/chart.ts
+++ b/lib/infobox/chart.ts
@@ -183,13 +183,18 @@ function renderD3Chart(
         .tickFormat(() => ""),
     );
 
+  // Pick an x-axis tick format that fits the visible span: time-of-day for
+  // short ranges (<= 2 days), day.month otherwise.
+  const spanMs = xDomain[1] - xDomain[0];
+  const xTickFormat = spanMs <= 2 * 864e5 ? timeFormat("%H:%M") : timeFormat("%d.%m.");
+
   svg
     .append("g")
     .attr("transform", `translate(0,${innerHeight})`)
     .call(
       axisBottom(xScale)
         .ticks(5)
-        .tickFormat(timeFormat("%m/%d") as (d: Date | { valueOf(): number }) => string),
+        .tickFormat(xTickFormat as (d: Date | { valueOf(): number }) => string),
     );
   svg.append("g").call(yAxis);
 


### PR DESCRIPTION
## Description

The x-axis was hardcoded to %m/%d, so short ranges (e.g. now-24h) showed the same day on every tick. Derive the format from the actual data span: %H:%M for spans up to 2 days, %d.%m. otherwise

## Motivation and Context

Better display of short time ranges

## How Has This Been Tested?

Browser, see screenshots

## Screenshots/links:

Old:
<img width="534" height="349" alt="grafik" src="https://github.com/user-attachments/assets/8c7b25e8-d7c2-4ecb-8c58-f822f9a2fe24" />

New:
<img width="521" height="255" alt="grafik" src="https://github.com/user-attachments/assets/e3e2388b-47c6-4924-b846-cb049c2d540b" />


## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
