### PR TITLE
[FEATURE] Support automatic map tile inversion in dark mode

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -47,6 +47,7 @@ Defines a List of Maps that are used as a background.
       "config": {
         "type": "osm",
         "maxZoom": 19,
+        "invertInDarkMode": true,
         "attribution": "<a href='https://github.com/freifunk/meshviewer/issues' target='_blank'>Report Bug</a> | Map data &copy; <a href\"http://openstreetmap.org\">OpenStreetMap</a> contributor"
       }
     },
@@ -60,6 +61,8 @@ Defines a List of Maps that are used as a background.
     }
   ],
 ```
+
+The `invertInDarkMode` boolean allows you to automatically invert standard map tiles (like light OpenStreetMap) via CSS when the app switches to dark mode, matching the dark aesthetic without needing a dedicated dark tile server. Note that this property is ignored for vector map layers.
 
 `fixedCenter` defines the default area that is visible when opening the map.
 

--- a/config.example.json
+++ b/config.example.json
@@ -10,6 +10,7 @@
       "config": {
         "type": "osm",
         "maxZoom": 19,
+        "invertInDarkMode": true,
         "attribution": "<a href='https://github.com/freifunk/meshviewer/issues' target='_blank'>Report Bug</a> | Map data &copy; <a href\"http://openstreetmap.org\">OpenStreetMap</a> contributor"
       }
     },

--- a/dev-fixtures/config.json
+++ b/dev-fixtures/config.json
@@ -54,7 +54,26 @@
       "url": "https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png",
       "config": {
         "maxZoom": 22,
-        "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a>, &copy; | <a href=\"https://carto.com/attribution\">CARTO</a>"
+        "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> | Map Data &copy; <a href=\"https://carto.com/attribution\">CARTO</a>"
+      }
+    },
+    {
+      "name": "OpenStreetMap",
+      "url": "https://tiles.aachen.freifunk.net/{z}/{x}/{y}.png",
+      "config": {
+        "type": "osm",
+        "maxZoom": 19,
+        "attribution": "Map data &copy; <a href=\"http://openstreetmap.org/copyright\">OpenStreetMap</a>",
+        "start": 10
+      }
+    },
+    {
+      "name": "EsriWorldImagery",
+      "url": "https://tiles.aachen.freifunk.net/EsriWorldImagery/{z}/{y}/{x}.png",
+      "config": {
+        "maxZoom": 19,
+        "start": 30,
+        "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> | Map Data &copy;  <a href=\"http://arcgis.com/about/\" target=\"_blank\">ArcGIS Sattelite</a>"
       }
     }
   ]

--- a/dev-fixtures/config.json
+++ b/dev-fixtures/config.json
@@ -54,6 +54,7 @@
       "url": "https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png",
       "config": {
         "maxZoom": 22,
+        "invertInDarkMode": true,
         "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> | Map Data &copy; <a href=\"https://carto.com/attribution\">CARTO</a>"
       }
     },
@@ -63,6 +64,7 @@
       "config": {
         "type": "osm",
         "maxZoom": 19,
+        "invertInDarkMode": true,
         "attribution": "Map data &copy; <a href=\"http://openstreetmap.org/copyright\">OpenStreetMap</a>",
         "start": 10
       }

--- a/lib/config_default.ts
+++ b/lib/config_default.ts
@@ -91,6 +91,7 @@ export interface MapLayer {
     start?: number; // Hour
     end?: number; // Hour
     order: number;
+    invertInDarkMode?: boolean;
   };
 }
 

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -90,14 +90,18 @@ export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typ
   });
 
   let layers = config.mapLayers.map(function (layer) {
+    let layerConfig = Object.assign({}, layer.config);
+    if (layerConfig.invertInDarkMode) {
+      layerConfig.className = (layerConfig.className ? layerConfig.className + " " : "") + "invert-in-dark-mode";
+    }
     return {
       name: layer.name,
       layer:
         layer.type == "vector"
           ? L.maplibreGL({
               style: layer.url,
-              attributionControl: { customAttribution: layer.config.attribution },
-              maxZoom: layer.config.maxZoom,
+              attributionControl: { customAttribution: layerConfig.attribution },
+              maxZoom: layerConfig.maxZoom,
             })
           : L.tileLayer(
               layer.url.replace(
@@ -106,7 +110,7 @@ export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typ
                   ? "webp"
                   : "png",
               ),
-              layer.config,
+              layerConfig,
             ),
     };
   });
@@ -161,15 +165,17 @@ export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typ
   });
 
   map.on("baselayerchange", function (e: any & { name: string }) {
-    const selectedLayer = baseLayers[e.name] as L.TileLayer & { options: L.TileLayerOptions & { mode?: string } };
-    if (selectedLayer && selectedLayer.options.maxZoom !== undefined) {
-      const maxZoom = selectedLayer.options.maxZoom;
-      map.options.maxZoom = maxZoom;
-      clientLayer.options.maxZoom = maxZoom;
-      labelLayer.options.maxZoom = maxZoom;
+    const selectedLayer = baseLayers[e.name] as L.TileLayer;
+    if (selectedLayer) {
+      if (selectedLayer.options.maxZoom !== undefined) {
+        const maxZoom = selectedLayer.options.maxZoom;
+        map.options.maxZoom = maxZoom;
+        clientLayer.options.maxZoom = maxZoom;
+        labelLayer.options.maxZoom = maxZoom;
 
-      if (map.getZoom() > maxZoom) {
-        map.setZoom(maxZoom);
+        if (map.getZoom() > maxZoom) {
+          map.setZoom(maxZoom);
+        }
       }
     }
   });

--- a/scss/dark.scss
+++ b/scss/dark.scss
@@ -39,6 +39,7 @@ variables.$color-online: color.adjust(variables.$color-online, $lightness: 40%);
 
     .invert-in-dark-mode {
       filter: invert(100%) hue-rotate(180deg) brightness(95%) contrast(90%);
+      will-change: filter;
     }
   }
 

--- a/scss/dark.scss
+++ b/scss/dark.scss
@@ -8,7 +8,7 @@ variables.$color-white: #1c1c13;
 variables.$color-black: #fefefe;
 variables.$color-map-background: #0d151c;
 
-variables.$color-online: color.adjust(variables.$color-online, $lightness: 25%);
+variables.$color-online: color.adjust(variables.$color-online, $lightness: 40%);
 
 .theme_dark {
   //@import 'modules/base';
@@ -36,6 +36,10 @@ variables.$color-online: color.adjust(variables.$color-online, $lightness: 25%);
   //@import 'modules/leaflet';
   .leaflet-container {
     background: variables.$color-map-background;
+
+    .invert-in-dark-mode {
+      filter: invert(100%) hue-rotate(180deg) brightness(95%) contrast(90%);
+    }
   }
 
   .leaflet-label {
@@ -48,6 +52,10 @@ variables.$color-online: color.adjust(variables.$color-online, $lightness: 25%);
     .leaflet-control-layers-toggle {
       background: color.adjust(variables.$color-white, $lightness: 10%);
       color: variables.$color-black;
+    }
+
+    .leaflet-control-attribution {
+      background: color.adjust(variables.$color-white, $alpha: -0.3);
     }
   }
 


### PR DESCRIPTION
## Description

fixes #382

This PR introduces an `invertInDarkMode` configuration option for map layers. When a user switches to dark mode, compliant raster map layers with `invertInDarkMode: true` will be automatically inverted using a CSS filter (`filter: invert(100%) hue-rotate(180deg) brightness(95%) contrast(90%)`). 

This creates a seamless dark mode aesthetic for standard light map layers (like OpenStreetMap or CartoDB) without needing to configure or rely on a dedicated dark tile server. It does not affect vector layers or satellite imagery like Esri (when opted out).

Additionally, this PR:
- Adjusts the `$color-online` links to be brighter and more readable against the dark background.
- Adds `will-change: filter;` to [ensure smooth map panning/zooming on lower-end devices](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/will-change).
- Documents the new `invertInDarkMode` option in `CONFIGURATION.md` and `config.example.json`.

## Motivation and Context

Previously, dark mode users were met with a glaringly bright background map because standard tiles are light by default. By selectively inverting compliant map layers, we provide a vastly superior and more cohesive dark mode experience out of the box.

Additionally, links utilizing the dark blue `$color-online` variable had extremely poor contrast against the dark background, making them almost impossible to read.

## How Has This Been Tested?

- Tested locally with multiple raster layers (CartoDB, OpenStreetMap) to ensure seamless inversion.
- Verified that node/client labels and lines (`ClientLayer`, `LabelLayer`) draw correctly (white text/icons) and are *not* accidentally inverted.
- Tested satellite layers (EsriWorldImagery) without the inversion flag to ensure they render normally in dark mode.
- Tested link contrast across the UI in both light and dark themes.

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
