### PR TITLE
fix vector map layers throw "L.maplibreGL is not a function"

### DIFF
--- a/lib/map.test.ts
+++ b/lib/map.test.ts
@@ -1,0 +1,8 @@
+import { expect, it } from "vitest";
+import source from "./map.ts?raw";
+
+// Only a production bundle snapshots leaflet's exports, so neither this suite
+// nor tsc can observe the resulting "L.maplibreGL is not a function" directly.
+it("map.ts imports leaflet's live exports", () => {
+  expect(source).not.toMatch(/import \* as \w+ from "leaflet"/);
+});

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -1,4 +1,5 @@
-import * as L from "leaflet";
+// Default import: a namespace snapshots leaflet's exports before the plugin below adds maplibreGL.
+import L from "leaflet";
 import "@maplibre/maplibre-gl-leaflet";
 
 import { ClientLayer } from "./map/clientlayer.js";


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

This is a simplified and improved version of #400

## Motivation and Context

Fixes #367 

leaflet is CommonJS; `@maplibre/maplibre-gl-leaflet` is a UMD plugin that adds
`maplibreGL` to leaflet's `module.exports` as a side effect. `import * as L`
compiles to a separate object whose key set is fixed when it is built, and it is
built before the plugin runs. The bundle assigns and calls on two different
objects:

```js
e.maplibreGL = function(t){ return new e.MaplibreGL(t) }   // plugin
Q.maplibreGL({style: e.url, ...})                          // map.ts
```

The default import is the live `module.exports` the plugin mutates, so both
sides refer to one object. Type checking is unaffected — the plugin's
`declare module "leaflet"` augmentation still resolves through it.

Only production builds are affected as the dev server rewrites a namespace import
of a CommonJS dependency and this is why `npm run dev` never shows it.

## How Has This Been Tested?

Tested with a production build (`npm run build`) served with `config.example.json`'s map layers, before and after:

| | `.leaflet-container` | tile pane children | layer control |
|---|---|---|---|
| before | absent | 0 | absent |
| after | present | 3 | `CartoDB`, `BaseMap.de (Vektor)` |

Tested with both Firefox and Chromium.

## Screenshots/links:

The old version makes nodes unclickable, so even though I clicked on a node, it only shows the overview:
```
TypeError: Q.maplibreGL is not a function
    h map.ts:97
    Vg map.ts:92
    f gui.ts:59
    p gui.ts:68
    view router.ts:96
    customRoute router.ts:132
    initRoutes router.ts:170
...
```
<img width="802" height="526" alt="image" src="https://github.com/user-attachments/assets/81a59b84-74bf-4f99-a0ae-74bddba8401e" />

And the new version shows both the map and makes nodes clickable again:
<img width="887" height="653" alt="image" src="https://github.com/user-attachments/assets/0d49ee6a-8af6-409f-9c04-d36024b31240" />



## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
