### PR TITLE
fix: clear node/link state to prevent invalid combined route (#401)

### DIFF
--- a/lib/utils/router.ts
+++ b/lib/utils/router.ts
@@ -204,7 +204,14 @@ export class Router extends Navigo {
       result = "#";
       merged = Object.assign({}, this.currentState, data);
     }
-
+    if (data && ("node" in data || "link" in data)) {
+      if ("node" in data) {
+        merged.link = undefined;
+      }
+      if ("link" in data) {
+        merged.node = undefined;
+      }
+    }
     for (const key in merged) {
       if (!Object.prototype.hasOwnProperty.call(merged, key)) {
         continue;


### PR DESCRIPTION
## Problem
`generateLink()` merges the current router state with new navigation data. When navigating to a `link`, the previous `node` value from `currentState` was still present (and vice versa), producing an invalid combined route like `/node123/link456` that the router couldn't match — causing a fallback redirect to home.

## Fix
`node` and `link` are mutually exclusive states. This change clears the other key when one is explicitly set in `generateLink()`, so navigating to a link drops any stale node state, and vice versa.

## Testing
- Reproduced the bug using dev fixtures (`npm run dev:fixtures`)
- Verified clicking a linked node now correctly navigates to that node's detail view instead of redirecting home
- All existing unit tests pass (`npm run test:unit`)
- Linted with `npm run lint:fix`, no issues

Fixes #401