### PR TITLE
[BUGFIX] refactor Router.generateLink to fix mutual exclusivity and prevent invalid combined routes

### DIFF
--- a/lib/utils/router.ts
+++ b/lib/utils/router.ts
@@ -195,27 +195,39 @@ export class Router extends Navigo {
   }
 
   generateLink(data?: Record<string, unknown>, full?: boolean) {
-    let result = "";
+    let result = full ? "" : "#";
+    // Cast to Record<string, any> to avoid TS strict errors when accessing properties
+    const base: Record<string, any> = full ? this.state : this.currentState;
 
-    let merged: Record<string, unknown>;
-    if (full) {
-      merged = Object.assign({}, this.state, data);
-    } else {
-      result = "#";
-      merged = Object.assign({}, this.currentState, data);
+    // 1. Resolve values (prioritizing new data)
+    const lang = data && data.lang !== undefined ? data.lang : base.lang;
+    const view = data && data.view !== undefined ? data.view : base.view;
+    const zoom = data && data.zoom !== undefined ? data.zoom : base.zoom;
+    const lat = data && data.lat !== undefined ? data.lat : base.lat;
+    const lng = data && data.lng !== undefined ? data.lng : base.lng;
+
+    // 2. Append base path config
+    if (lang) result += "/" + String(lang);
+    if (view) result += "/" + String(view);
+
+    // 3. Append the single valid target (Prioritize incoming 'data' overrides, fallback to base)
+    if (data && data.node !== undefined) {
+      result += "/" + String(data.node);
+    } else if (data && data.link !== undefined) {
+      result += "/" + String(data.link);
+    } else if (data && (data.zoom !== undefined || data.lat !== undefined || data.lng !== undefined)) {
+      if (lat !== undefined) {
+        result += "/" + String(zoom) + "/" + String(lat) + "/" + String(lng);
+      }
+    } else if (base.node) {
+      result += "/" + String(base.node);
+    } else if (base.link) {
+      result += "/" + String(base.link);
+    } else if (lat !== undefined) {
+      result += "/" + String(zoom) + "/" + String(lat) + "/" + String(lng);
     }
 
-    for (const key in merged) {
-      if (!Object.prototype.hasOwnProperty.call(merged, key)) {
-        continue;
-      }
-      const v = merged[key];
-      if (v === undefined || v === "") {
-        continue;
-      }
-      result += "/" + String(v);
-    }
-
+    // 4. Append query params
     const params = this.getParams();
     result += this.paramsToUrl(params);
 


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

Navigating between mutually exclusive targets (e.g. from a node to a link) using generateLink resulted in an invalid combined URL path (e.g. `#/en/map/node123/link456`) that fails the regex parser, causing unwanted fallbacks to the default view.

The previous implementation relied on Object.assign combining conflicting states and blindly looping over object keys to build the URL string. This refactor replaces the fragile `for (const key in merged)` loop with an explicit, statically ordered URL builder.

This enforces strict mutual exclusivity for all three location targets (nodes, links, and map coordinates) and guarantees the path order perfectly matches MESHVIEWER_ROUTE_PATTERN.

## Motivation and Context

Fixes https://github.com/freifunk/meshviewer/issues/401

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
